### PR TITLE
feat(sqs): add request template support for sqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ custom:
           'integration.request.querystring.MessageAttribute.2.Value.DataType': "'String'"
 ```
 
+The preferred way to pass `MessageAttribute` parameters is via a request body mapping template. Any `requestParameters` keys that begin with `integration.request.querystring.` will be automatically placed in the request body to maintain backward compatibility with existing implementations.
+
 #### Customizing request body mapping templates
 
 See the [SQS section](#sqs-1) under [Customizing request body mapping templates](#customizing-request-body-mapping-templates)

--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -247,7 +247,8 @@ const proxiesSchemas = {
   sqs: Joi.object({
     sqs: proxy.append({
       queueName: stringOrGetAtt('queueName', 'QueueName').required(),
-      requestParameters
+      requestParameters,
+      request
     })
   }),
   dynamodb: Joi.object({

--- a/lib/apiGateway/validate.test.js
+++ b/lib/apiGateway/validate.test.js
@@ -1555,6 +1555,63 @@ describe('#validateServiceProxies()', () => {
 
       expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.not.throw()
     })
+
+    it('should throw error if request is missing the template property', () => {
+      serverlessApigatewayServiceProxy.serverless.service.custom = {
+        apiGatewayServiceProxies: [
+          {
+            sqs: {
+              path: '/sqs',
+              method: 'post',
+              queueName: 'queueName',
+              request: { xxx: { 'application/json': 'mappingTemplate' } }
+            }
+          }
+        ]
+      }
+
+      expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.throw(
+        serverless.classes.Error,
+        'child "sqs" fails because [child "request" fails because [child "template" fails because ["template" is required]]]'
+      )
+    })
+
+    it('should throw error if request is not a mapping template object', () => {
+      serverlessApigatewayServiceProxy.serverless.service.custom = {
+        apiGatewayServiceProxies: [
+          {
+            sqs: {
+              path: '/sqs',
+              method: 'post',
+              queueName: 'queueName',
+              request: { template: [] }
+            }
+          }
+        ]
+      }
+
+      expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.throw(
+        serverless.classes.Error,
+        'child "sqs" fails because [child "request" fails because [child "template" fails because ["template" must be an object]]]'
+      )
+    })
+
+    it('should not throw error if request is a mapping template object', () => {
+      serverlessApigatewayServiceProxy.serverless.service.custom = {
+        apiGatewayServiceProxies: [
+          {
+            sqs: {
+              path: '/sqs',
+              method: 'post',
+              queueName: 'queueName',
+              request: { template: { 'application/json': 'mappingTemplate' } }
+            }
+          }
+        ]
+      }
+
+      expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.not.throw()
+    })
   })
 
   describe('dynamodb', () => {

--- a/lib/package/sqs/compileMethodsToSqs.js
+++ b/lib/package/sqs/compileMethodsToSqs.js
@@ -58,14 +58,14 @@ module.exports = {
           { queueName: http.queueName }
         ]
       },
+      PassthroughBehavior: 'NEVER',
       RequestParameters: _.merge(
         {
-          'integration.request.querystring.Action': "'SendMessage'",
-          'integration.request.querystring.MessageBody': 'method.request.body'
+          'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
         },
         http.requestParameters
       ),
-      RequestTemplates: { 'application/json': '{statusCode:200}' }
+      RequestTemplates: this.getSqsIntegrationRequestTemplates(http)
     }
 
     const integrationResponse = {
@@ -100,5 +100,20 @@ module.exports = {
         Integration: integration
       }
     }
+  },
+
+  getSqsIntegrationRequestTemplates(http) {
+    const defaultRequestTemplates = this.getDefaultSqsRequestTemplates()
+    return Object.assign(defaultRequestTemplates, _.get(http, ['request', 'template']))
+  },
+
+  getDefaultSqsRequestTemplates() {
+    return {
+      'application/json': this.buildDefaultSqsRequestTemplate()
+    }
+  },
+
+  buildDefaultSqsRequestTemplate() {
+    return 'Action=SendMessage&MessageBody=$util.urlEncode($input.body)'
   }
 }

--- a/lib/package/sqs/compileMethodsToSqs.js
+++ b/lib/package/sqs/compileMethodsToSqs.js
@@ -48,6 +48,12 @@ module.exports = {
       'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn']
     }
 
+    const isQuerystring = (_value, parameter) =>
+      parameter.trim().startsWith('integration.request.querystring.')
+
+    const requestParametersQuerystrings = _.pickBy(http.requestParameters, isQuerystring)
+    const requestParametersOthers = _.omitBy(http.requestParameters, isQuerystring)
+
     const integration = {
       IntegrationHttpMethod: 'POST',
       Type: 'AWS',
@@ -63,9 +69,9 @@ module.exports = {
         {
           'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
         },
-        http.requestParameters
+        requestParametersOthers
       ),
-      RequestTemplates: this.getSqsIntegrationRequestTemplates(http)
+      RequestTemplates: this.getSqsIntegrationRequestTemplates(http, requestParametersQuerystrings)
     }
 
     let integrationResponse
@@ -140,9 +146,29 @@ module.exports = {
     }
   },
 
-  getSqsIntegrationRequestTemplates(http) {
-    const defaultRequestTemplates = this.getDefaultSqsRequestTemplates()
-    return Object.assign(defaultRequestTemplates, _.get(http, ['request', 'template']))
+  getSqsIntegrationRequestTemplates(http, requestParametersQuerystrings) {
+    const defaultRequestTemplates = this.getDefaultSqsRequestTemplates(http)
+    const customRequestTemplates = _.get(http, ['request', 'template'])
+
+    if (_.isEmpty(customRequestTemplates) && !_.isEmpty(requestParametersQuerystrings)) {
+      requestParametersQuerystrings = _.map(requestParametersQuerystrings, (value, parameter) => {
+        return [
+          parameter.trim().replace('integration.request.querystring.', ''),
+          value
+            .trim()
+            .replace(/^context\.(.+)$/, '$$util.urlEncode($$context.$1)')
+            .replace(/(^')|('$)/g, '')
+        ].join('=')
+      })
+
+      return {
+        'application/json': `${
+          defaultRequestTemplates['application/json']
+        }&${requestParametersQuerystrings.join('&')}`
+      }
+    }
+
+    return Object.assign(defaultRequestTemplates, customRequestTemplates)
   },
 
   getDefaultSqsRequestTemplates() {

--- a/lib/package/sqs/compileMethodsToSqs.js
+++ b/lib/package/sqs/compileMethodsToSqs.js
@@ -2,6 +2,9 @@
 
 const _ = require('lodash')
 
+const requestParameterIsQuerystring = (_value, parameter) =>
+  parameter.trim().startsWith('integration.request.querystring.')
+
 module.exports = {
   compileMethodsToSqs() {
     this.validated.events.forEach((event) => {
@@ -48,12 +51,6 @@ module.exports = {
       'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn']
     }
 
-    const isQuerystring = (_value, parameter) =>
-      parameter.trim().startsWith('integration.request.querystring.')
-
-    const requestParametersQuerystrings = _.pickBy(http.requestParameters, isQuerystring)
-    const requestParametersOthers = _.omitBy(http.requestParameters, isQuerystring)
-
     const integration = {
       IntegrationHttpMethod: 'POST',
       Type: 'AWS',
@@ -69,9 +66,9 @@ module.exports = {
         {
           'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
         },
-        requestParametersOthers
+        _.omitBy(http.requestParameters, requestParameterIsQuerystring)
       ),
-      RequestTemplates: this.getSqsIntegrationRequestTemplates(http, requestParametersQuerystrings)
+      RequestTemplates: this.getSqsIntegrationRequestTemplates(http)
     }
 
     let integrationResponse
@@ -146,9 +143,13 @@ module.exports = {
     }
   },
 
-  getSqsIntegrationRequestTemplates(http, requestParametersQuerystrings) {
+  getSqsIntegrationRequestTemplates(http) {
     const defaultRequestTemplates = this.getDefaultSqsRequestTemplates(http)
     const customRequestTemplates = _.get(http, ['request', 'template'])
+    let requestParametersQuerystrings = _.pickBy(
+      http.requestParameters,
+      requestParameterIsQuerystring
+    )
 
     if (_.isEmpty(customRequestTemplates) && !_.isEmpty(requestParametersQuerystrings)) {
       requestParametersQuerystrings = _.map(requestParametersQuerystrings, (value, parameter) => {

--- a/lib/package/sqs/compileMethodsToSqs.test.js
+++ b/lib/package/sqs/compileMethodsToSqs.test.js
@@ -73,11 +73,13 @@ describe('#compileMethodsToSqs()', () => {
                 }
               ]
             },
+            PassthroughBehavior: 'NEVER',
             RequestParameters: {
-              'integration.request.querystring.Action': "'SendMessage'",
-              'integration.request.querystring.MessageBody': 'method.request.body'
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
             },
-            RequestTemplates: { 'application/json': '{statusCode:200}' },
+            RequestTemplates: {
+              'application/json': 'Action=SendMessage&MessageBody=$util.urlEncode($input.body)'
+            },
             IntegrationResponses: [
               {
                 StatusCode: 200,
@@ -173,11 +175,13 @@ describe('#compileMethodsToSqs()', () => {
                 }
               ]
             },
+            PassthroughBehavior: 'NEVER',
             RequestParameters: {
-              'integration.request.querystring.Action': "'SendMessage'",
-              'integration.request.querystring.MessageBody': 'method.request.body'
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
             },
-            RequestTemplates: { 'application/json': '{statusCode:200}' },
+            RequestTemplates: {
+              'application/json': 'Action=SendMessage&MessageBody=$util.urlEncode($input.body)'
+            },
             IntegrationResponses: [
               {
                 StatusCode: 200,
@@ -272,11 +276,13 @@ describe('#compileMethodsToSqs()', () => {
                 }
               ]
             },
+            PassthroughBehavior: 'NEVER',
             RequestParameters: {
-              'integration.request.querystring.Action': "'SendMessage'",
-              'integration.request.querystring.MessageBody': 'method.request.body'
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
             },
-            RequestTemplates: { 'application/json': '{statusCode:200}' },
+            RequestTemplates: {
+              'application/json': 'Action=SendMessage&MessageBody=$util.urlEncode($input.body)'
+            },
             IntegrationResponses: [
               {
                 StatusCode: 200,
@@ -399,11 +405,13 @@ describe('#compileMethodsToSqs()', () => {
                 }
               ]
             },
+            PassthroughBehavior: 'NEVER',
             RequestParameters: {
-              'integration.request.querystring.Action': "'SendMessage'",
-              'integration.request.querystring.MessageBody': 'method.request.body'
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
             },
-            RequestTemplates: { 'application/json': '{statusCode:200}' },
+            RequestTemplates: {
+              'application/json': 'Action=SendMessage&MessageBody=$util.urlEncode($input.body)'
+            },
             IntegrationResponses: [
               {
                 StatusCode: 200,
@@ -486,11 +494,13 @@ describe('#compileMethodsToSqs()', () => {
                 }
               ]
             },
+            PassthroughBehavior: 'NEVER',
             RequestParameters: {
-              'integration.request.querystring.Action': "'SendMessage'",
-              'integration.request.querystring.MessageBody': 'method.request.body'
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
             },
-            RequestTemplates: { 'application/json': '{statusCode:200}' },
+            RequestTemplates: {
+              'application/json': 'Action=SendMessage&MessageBody=$util.urlEncode($input.body)'
+            },
             IntegrationResponses: [
               {
                 StatusCode: 200,
@@ -573,13 +583,106 @@ describe('#compileMethodsToSqs()', () => {
                 }
               ]
             },
+            PassthroughBehavior: 'NEVER',
             RequestParameters: {
-              'integration.request.querystring.Action': "'SendMessage'",
-              'integration.request.querystring.MessageBody': 'method.request.body',
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'",
               key1: 'value1',
               key2: 'value2'
             },
-            RequestTemplates: { 'application/json': '{statusCode:200}' },
+            RequestTemplates: {
+              'application/json': 'Action=SendMessage&MessageBody=$util.urlEncode($input.body)'
+            },
+            IntegrationResponses: [
+              {
+                StatusCode: 200,
+                SelectionPattern: 200,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 400,
+                SelectionPattern: 400,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 500,
+                SelectionPattern: 500,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 200 },
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 400 },
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 500 }
+          ]
+        }
+      }
+    })
+  })
+
+  it('should return a custom response template for application/json when one is given', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sqs',
+          http: {
+            queueName: 'myQueue',
+            path: 'sqs',
+            method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            },
+            request: {
+              template: {
+                'application/json': '##This template is just a comment'
+              }
+            }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      sqs: {
+        name: 'sqs',
+        resourceLogicalId: 'ApiGatewayResourceSqs'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToSqs()
+
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodsqsPost: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RequestParameters: {},
+          AuthorizationType: 'NONE',
+          AuthorizationScopes: undefined,
+          AuthorizerId: undefined,
+          ApiKeyRequired: false,
+          ResourceId: { Ref: 'ApiGatewayResourceSqs' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          Integration: {
+            IntegrationHttpMethod: 'POST',
+            Type: 'AWS',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
+            Uri: {
+              'Fn::Sub': [
+                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                {
+                  queueName: 'myQueue'
+                }
+              ]
+            },
+            PassthroughBehavior: 'NEVER',
+            RequestParameters: {
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
+            },
+            RequestTemplates: { 'application/json': '##This template is just a comment' },
             IntegrationResponses: [
               {
                 StatusCode: 200,

--- a/lib/package/sqs/compileMethodsToSqs.test.js
+++ b/lib/package/sqs/compileMethodsToSqs.test.js
@@ -714,6 +714,212 @@ describe('#compileMethodsToSqs()', () => {
     })
   })
 
+  it('should return a custom request template for application/json when one is given and not include custom request querystring parameters if provided', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sqs',
+          http: {
+            queueName: 'myQueue',
+            path: 'sqs',
+            method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            },
+            requestParameters: {
+              'integration.request.header.x-my-custom-header': "'foobar'",
+              'integration.request.querystring.MessageAttribute.1.Name': "'cognitoIdentityId'",
+              'integration.request.querystring.MessageAttribute.1.Value.StringValue':
+                'context.identity.cognitoIdentityId',
+              'integration.request.querystring.MessageAttribute.1.Value.DataType': "'String'",
+              'integration.request.querystring.MessageAttribute.2.Name':
+                "'cognitoAuthenticationProvider'",
+              'integration.request.querystring.MessageAttribute.2.Value.StringValue':
+                'context.identity.cognitoAuthenticationProvider',
+              'integration.request.querystring.MessageAttribute.2.Value.DataType': "'String'"
+            },
+            request: {
+              template: {
+                'application/json': '##This template is just a comment'
+              }
+            }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      sqs: {
+        name: 'sqs',
+        resourceLogicalId: 'ApiGatewayResourceSqs'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToSqs()
+
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodsqsPost: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RequestParameters: {},
+          AuthorizationType: 'NONE',
+          AuthorizationScopes: undefined,
+          AuthorizerId: undefined,
+          ApiKeyRequired: false,
+          ResourceId: { Ref: 'ApiGatewayResourceSqs' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          Integration: {
+            IntegrationHttpMethod: 'POST',
+            Type: 'AWS',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
+            Uri: {
+              'Fn::Sub': [
+                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                {
+                  queueName: 'myQueue'
+                }
+              ]
+            },
+            PassthroughBehavior: 'NEVER',
+            RequestParameters: {
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'",
+              'integration.request.header.x-my-custom-header': "'foobar'"
+            },
+            RequestTemplates: { 'application/json': '##This template is just a comment' },
+            IntegrationResponses: [
+              {
+                StatusCode: 200,
+                SelectionPattern: 200,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 400,
+                SelectionPattern: 400,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 500,
+                SelectionPattern: 500,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 200 },
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 400 },
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 500 }
+          ]
+        }
+      }
+    })
+  })
+
+  it('should return a custom request template for application/json when custom request querystring parameters are provided and no custom request template is provided', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sqs',
+          http: {
+            queueName: 'myQueue',
+            path: 'sqs',
+            method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            },
+            requestParameters: {
+              'integration.request.header.x-my-custom-header': "'foobar'",
+              'integration.request.querystring.MessageAttribute.1.Name': "'cognitoIdentityId'",
+              'integration.request.querystring.MessageAttribute.1.Value.StringValue':
+                'context.identity.cognitoIdentityId',
+              'integration.request.querystring.MessageAttribute.1.Value.DataType': "'String'",
+              'integration.request.querystring.MessageAttribute.2.Name':
+                "'cognitoAuthenticationProvider'",
+              'integration.request.querystring.MessageAttribute.2.Value.StringValue':
+                'context.identity.cognitoAuthenticationProvider',
+              'integration.request.querystring.MessageAttribute.2.Value.DataType': "'String'"
+            }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      sqs: {
+        name: 'sqs',
+        resourceLogicalId: 'ApiGatewayResourceSqs'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToSqs()
+
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodsqsPost: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RequestParameters: {},
+          AuthorizationType: 'NONE',
+          AuthorizationScopes: undefined,
+          AuthorizerId: undefined,
+          ApiKeyRequired: false,
+          ResourceId: { Ref: 'ApiGatewayResourceSqs' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          Integration: {
+            IntegrationHttpMethod: 'POST',
+            Type: 'AWS',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
+            Uri: {
+              'Fn::Sub': [
+                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                {
+                  queueName: 'myQueue'
+                }
+              ]
+            },
+            PassthroughBehavior: 'NEVER',
+            RequestParameters: {
+              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'",
+              'integration.request.header.x-my-custom-header': "'foobar'"
+            },
+            RequestTemplates: {
+              'application/json':
+                'Action=SendMessage&MessageBody=$util.urlEncode($input.body)&MessageAttribute.1.Name=cognitoIdentityId&MessageAttribute.1.Value.StringValue=$util.urlEncode($context.identity.cognitoIdentityId)&MessageAttribute.1.Value.DataType=String&MessageAttribute.2.Name=cognitoAuthenticationProvider&MessageAttribute.2.Value.StringValue=$util.urlEncode($context.identity.cognitoAuthenticationProvider)&MessageAttribute.2.Value.DataType=String'
+            },
+            IntegrationResponses: [
+              {
+                StatusCode: 200,
+                SelectionPattern: 200,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 400,
+                SelectionPattern: 400,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 500,
+                SelectionPattern: 500,
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 200 },
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 400 },
+            { ResponseParameters: {}, ResponseModels: {}, StatusCode: 500 }
+          ]
+        }
+      }
+    })
+  })
+
   it('should set Credentials to roleArn when a custom role is configured', () => {
     const http = {
       queueName: 'myQueue',


### PR DESCRIPTION
Allows the addition of `request.template.<content-type>` to `serverless.yml` under `apiGatewayServiceProxies`.

Changes the approach to passing basic `Action` and `MessageBody` values by passing them in the POST request payload instead of via querystrings. This means that the prior default `RequestParameters` have been replaced with a single default which sets the `Content-Type` to `application/x-www-form-urlencoded`.

An example config which satisfies the requirements for an SQS FIFO queue follows.

Given a request payload of:

```json
{
  "event_type": "message",
  "event_id": "ABC123",
  "message": "Hello!"
}
```

Then the following config inside `serverless.yml`:

```yaml
  apiGatewayServiceProxies:
    - sqs:
        path: /{version}/event/receiver
        method: post
        queueName:
          Fn::GetAtt:
            - eventQueue
            - "QueueName"
        request:
          template:
            application/json: |-
              #set ($body = $util.parseJson($input.body))
              Action=SendMessage##
              &MessageGroupId=$util.urlEncode($body.event_type)##
              &MessageDeduplicationId=$util.urlEncode($body.event_id)##
              &MessageAttribute.1.Name=$util.urlEncode("X-Custom-Signature")##
              &MessageAttribute.1.Value.DataType=String##
              &MessageAttribute.1.Value.StringValue=$util.urlEncode($input.params("X-Custom-Signature"))##
              &MessageBody=$util.urlEncode($input.body)
```

Will produce the following request body (substituting some values with tags):

```
Action=SendMessage&MessageGroupId=message&MessageDeduplicationId=ABC123&MessageAttribute.1.Name=X-Custom-Signature&MessageAttribute.1.Value.DataType=String&MessageAttribute.1.Value.StringValue=<related-header-value>&MessageBody=<url-encoded-request-payload>
```

It is usually possible to omit the url encoding of the `$input.body` as SQS does not seem to care too much about that, but I have not tested with any potentially problematic characters.

This PR is in response to #80