### PR TITLE
feat(sqs): add response template support for sqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This Serverless Framework plugin supports the AWS service proxy integration feat
   - [Kinesis](#kinesis)
   - [SQS](#sqs)
     - [Customizing request parameters](#customizing-request-parameters)
+    - [Customizing responses](#customizing-responses)
   - [S3](#s3)
     - [Customizing request parameters](#customizing-request-parameters-1)
     - [Customize the Path Override in API Gateway](#customize-the-path-override-in-api-gateway)
@@ -154,6 +155,57 @@ custom:
           'integration.request.querystring.MessageAttribute.2.Value.StringValue': 'context.identity.cognitoAuthenticationProvider'
           'integration.request.querystring.MessageAttribute.2.Value.DataType': "'String'"
 ```
+
+#### Customizing responses
+
+##### Simplified response template customization
+
+You can get a simple customization of the responses by providing a template for the possible responses. The template is assumed to be `application/json`.
+
+```yml
+custom:
+  apiGatewayServiceProxies:
+    - sqs:
+        path: /queue
+        method: post
+        queueName: !GetAtt MyQueue.QueueName
+        cors: true
+        response:
+          template:
+            # `success` is used when the integration response is 200
+            success: |-
+              { "message: "accepted" }
+            # `clientError` is used when the integration response is 400
+            clientError: |-
+              { "message": "there is an error in your request" }
+            # `serverError` is used when the integration response is 500
+            serverError: |-
+              { "message": "there was an error handling your request" }
+```
+
+##### Full response customization
+
+If you want more control over the integration response, you can
+provide an array of objects for the `response` value:
+
+```yml
+custom:
+  apiGatewayServiceProxies:
+    - sqs:
+        path: /queue
+        method: post
+        queueName: !GetAtt MyQueue.QueueName
+        cors: true
+        response:
+          - statusCode: 200
+            selectionPattern: '2\\d{2}'
+            responseParameters: {}
+            responseTemplates:
+              application/json: |-
+                { "message": "accepted" }
+```
+
+The object keys correspond to the API Gateway [integration response](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-integration-integrationresponse.html#cfn-apigateway-method-integration-integrationresponse-responseparameters) object.
 
 ### S3
 

--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -218,6 +218,24 @@ const response = Joi.object({
   })
 })
 
+const sqsResponse = Joi.alternatives().try([
+  Joi.object({
+    template: Joi.object().keys({
+      success: Joi.string(),
+      clientError: Joi.string(),
+      serverError: Joi.string()
+    })
+  }),
+  Joi.array().items(
+    Joi.object().keys({
+      statusCode: Joi.alternatives().try([Joi.number(), Joi.string()]),
+      selectionPattern: Joi.alternatives().try([Joi.number(), Joi.string()]),
+      responseParameters: Joi.object(),
+      responseTemplates: Joi.object()
+    })
+  )
+])
+
 const allowedProxies = ['kinesis', 'sqs', 's3', 'sns', 'dynamodb', 'eventbridge']
 
 const proxiesSchemas = {
@@ -247,7 +265,8 @@ const proxiesSchemas = {
   sqs: Joi.object({
     sqs: proxy.append({
       queueName: stringOrGetAtt('queueName', 'QueueName').required(),
-      requestParameters
+      requestParameters,
+      response: sqsResponse
     })
   }),
   dynamodb: Joi.object({

--- a/lib/package/sqs/compileMethodsToSqs.js
+++ b/lib/package/sqs/compileMethodsToSqs.js
@@ -68,27 +68,65 @@ module.exports = {
       RequestTemplates: { 'application/json': '{statusCode:200}' }
     }
 
-    const integrationResponse = {
-      IntegrationResponses: [
-        {
-          StatusCode: 200,
-          SelectionPattern: 200,
-          ResponseParameters: {},
-          ResponseTemplates: {}
-        },
-        {
-          StatusCode: 400,
-          SelectionPattern: 400,
-          ResponseParameters: {},
-          ResponseTemplates: {}
-        },
-        {
-          StatusCode: 500,
-          SelectionPattern: 500,
-          ResponseParameters: {},
-          ResponseTemplates: {}
-        }
-      ]
+    let integrationResponse
+
+    if (_.get(http.response, 'template.success')) {
+      // support a simplified model
+      integrationResponse = {
+        IntegrationResponses: [
+          {
+            StatusCode: 200,
+            SelectionPattern: 200,
+            ResponseParameters: {},
+            ResponseTemplates: this.getSQSIntegrationResponseTemplate(http, 'success')
+          },
+          {
+            StatusCode: 400,
+            SelectionPattern: 400,
+            ResponseParameters: {},
+            ResponseTemplates: this.getSQSIntegrationResponseTemplate(http, 'clientError')
+          },
+          {
+            StatusCode: 500,
+            SelectionPattern: 500,
+            ResponseParameters: {},
+            ResponseTemplates: this.getSQSIntegrationResponseTemplate(http, 'serverError')
+          }
+        ]
+      }
+    } else if (_.isArray(http.response)) {
+      // support full usage
+      integrationResponse = {
+        IntegrationResponses: http.response.map((i) => ({
+          StatusCode: i.statusCode,
+          SelectionPattern: i.selectionPattern || i.statusCode,
+          ResponseParameters: i.responseParameters || {},
+          ResponseTemplates: i.responseTemplates || {}
+        }))
+      }
+    } else {
+      integrationResponse = {
+        IntegrationResponses: [
+          {
+            StatusCode: 200,
+            SelectionPattern: 200,
+            ResponseParameters: {},
+            ResponseTemplates: {}
+          },
+          {
+            StatusCode: 400,
+            SelectionPattern: 400,
+            ResponseParameters: {},
+            ResponseTemplates: {}
+          },
+          {
+            StatusCode: 500,
+            SelectionPattern: 500,
+            ResponseParameters: {},
+            ResponseTemplates: {}
+          }
+        ]
+      }
     }
 
     this.addCors(http, integrationResponse)
@@ -100,5 +138,10 @@ module.exports = {
         Integration: integration
       }
     }
+  },
+
+  getSQSIntegrationResponseTemplate(http, statusType) {
+    const template = _.get(http, ['response', 'template', statusType])
+    return Object.assign({}, template && { 'application/json': template })
   }
 }

--- a/lib/package/sqs/compileMethodsToSqs.test.js
+++ b/lib/package/sqs/compileMethodsToSqs.test.js
@@ -656,4 +656,189 @@ describe('#compileMethodsToSqs()', () => {
         .Properties.RequestParameters
     ).to.be.deep.equal({ 'method.request.header.Custom-Header': true })
   })
+
+  it('should throw error if simplified response template uses an unsupported key', () => {
+    serverlessApigatewayServiceProxy.serverless.service.custom = {
+      apiGatewayServiceProxies: [
+        {
+          sqs: {
+            path: '/sqs',
+            method: 'post',
+            queueName: 'queueName',
+            response: {
+              template: {
+                test: 'test template'
+              }
+            }
+          }
+        }
+      ]
+    }
+
+    expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.throw(
+      serverless.classes.Error,
+      'child "sqs" fails because [child "response" fails because [child "template" fails because ["test" is not allowed], "response" must be an array]]'
+    )
+  })
+
+  it('should throw error if complex response template uses an unsupported key', () => {
+    serverlessApigatewayServiceProxy.serverless.service.custom = {
+      apiGatewayServiceProxies: [
+        {
+          sqs: {
+            path: '/sqs',
+            method: 'post',
+            queueName: 'queueName',
+            response: [
+              {
+                test: 'test'
+              }
+            ]
+          }
+        }
+      ]
+    }
+
+    expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.throw(
+      serverless.classes.Error,
+      'child "sqs" fails because [child "response" fails because ["response" must be an object, "response" at position 0 fails because ["test" is not allowed]]]'
+    )
+  })
+
+  it('should transform simplified integration responses', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sqs',
+          http: {
+            queueName: 'myQueue',
+            path: 'sqs',
+            method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            },
+            response: {
+              template: {
+                success: 'success template',
+                clientError: 'client error template',
+                serverError: 'server error template'
+              }
+            }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      sqs: {
+        name: 'sqs',
+        resourceLogicalId: 'ApiGatewayResourceSqs'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToSqs()
+
+    expect(
+      serverless.service.provider.compiledCloudFormationTemplate.Resources.ApiGatewayMethodsqsPost
+        .Properties.Integration.IntegrationResponses
+    ).to.be.deep.equal([
+      {
+        StatusCode: 200,
+        SelectionPattern: 200,
+        ResponseParameters: {},
+        ResponseTemplates: {
+          'application/json': 'success template'
+        }
+      },
+      {
+        StatusCode: 400,
+        SelectionPattern: 400,
+        ResponseParameters: {},
+        ResponseTemplates: {
+          'application/json': 'client error template'
+        }
+      },
+      {
+        StatusCode: 500,
+        SelectionPattern: 500,
+        ResponseParameters: {},
+        ResponseTemplates: {
+          'application/json': 'server error template'
+        }
+      }
+    ])
+  })
+
+  it('should transform complex integration responses', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 'sqs',
+          http: {
+            queueName: 'myQueue',
+            path: 'sqs',
+            method: 'post',
+            auth: {
+              authorizationType: 'NONE'
+            },
+            response: [
+              {
+                statusCode: 200,
+                responseTemplates: {
+                  'text/plain': 'ok'
+                }
+              },
+              {
+                statusCode: 400,
+                selectionPattern: '4\\d{2}',
+                responseParameters: {
+                  a: 'b'
+                }
+              },
+              {
+                statusCode: 500
+              }
+            ]
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      sqs: {
+        name: 'sqs',
+        resourceLogicalId: 'ApiGatewayResourceSqs'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToSqs()
+
+    expect(
+      serverless.service.provider.compiledCloudFormationTemplate.Resources.ApiGatewayMethodsqsPost
+        .Properties.Integration.IntegrationResponses
+    ).to.be.deep.equal([
+      {
+        StatusCode: 200,
+        SelectionPattern: 200,
+        ResponseParameters: {},
+        ResponseTemplates: {
+          'text/plain': 'ok'
+        }
+      },
+      {
+        StatusCode: 400,
+        SelectionPattern: '4\\d{2}',
+        ResponseParameters: {
+          a: 'b'
+        },
+        ResponseTemplates: {}
+      },
+      {
+        StatusCode: 500,
+        SelectionPattern: 500,
+        ResponseParameters: {},
+        ResponseTemplates: {}
+      }
+    ])
+  })
 })


### PR DESCRIPTION
Adds support for response templates for SQS.

Supports the simplified response structure supported for Kinesis (see #54) but also allows more-complex integration response mappings.

Related to #80, #86.