### PR TITLE
feat(sqs): full backwards compatibility for sqs without a custom body

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ custom:
           'integration.request.querystring.MessageAttribute.2.Value.DataType': "'String'"
 ```
 
-The preferred way to pass `MessageAttribute` parameters is via a request body mapping template. Any `requestParameters` keys that begin with `integration.request.querystring.` will be automatically placed in the request body to maintain backward compatibility with existing implementations.
+The alternative way to pass `MessageAttribute` parameters is via a request body mapping template.
 
 #### Customizing request body mapping templates
 
@@ -714,7 +714,7 @@ Source: [How to connect SNS to Kinesis for cross-account delivery via API Gatewa
 
 #### SQS
 
-Customizing SQS request templates requires us to force all requests to use an `application/x-www-form-urlencoded` style body. The plugin sets the `Content-Type` to `application/x-www-form-urlencoded` for you, but API Gateway will still look for the template under the `application/json` request template type, so that is where you need to configure you request body in `serverless.yml`:
+Customizing SQS request templates requires us to force all requests to use an `application/x-www-form-urlencoded` style body. The plugin sets the `Content-Type` header to `application/x-www-form-urlencoded` for you, but API Gateway will still look for the template under the `application/json` request template type, so that is where you need to configure you request body in `serverless.yml`:
 
 ```yml
 custom:
@@ -741,6 +741,8 @@ Note that the `##` at the end of each line is an empty comment. In VTL this has 
 Be careful when mixing additional `requestParameters` into your SQS endpoint as you may overwrite the `integration.request.header.Content-Type` and stop the request template from being parsed correctly. You may also unintentionally create conflicts between parameters passed using `requestParameters` and those in your request template. Typically you should only use the request template if you need to manipulate the incoming request body in some way.
 
 Your custom template must also set the `Action` and `MessageBody` parameters, as these will not be added for you by the plugin.
+
+When using a custom request body, headers sent by a client will no longer be passed through to the SQS queue (`PassthroughBehavior` is automatically set to `NEVER`). You will need to pass through headers sent by the client explicitly in the request body. Also, any custom querystring parameters in the `requestParameters` array will be ignored. These also need to be added via the custom request body.
 
 #### SNS
 

--- a/lib/package/sqs/compileMethodsToSqs.js
+++ b/lib/package/sqs/compileMethodsToSqs.js
@@ -60,15 +60,29 @@ module.exports = {
           'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
           { queueName: http.queueName }
         ]
-      },
-      PassthroughBehavior: 'NEVER',
-      RequestParameters: _.merge(
+      }
+    }
+
+    const customRequestTemplates = _.get(http, ['request', 'template'])
+
+    if (_.isEmpty(customRequestTemplates)) {
+      integration.RequestParameters = _.merge(
+        {
+          'integration.request.querystring.Action': "'SendMessage'",
+          'integration.request.querystring.MessageBody': 'method.request.body'
+        },
+        http.requestParameters
+      )
+      integration.RequestTemplates = { 'application/json': '{statusCode:200}' }
+    } else {
+      integration.PassthroughBehavior = 'NEVER'
+      integration.RequestParameters = _.merge(
         {
           'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
         },
         _.omitBy(http.requestParameters, requestParameterIsQuerystring)
-      ),
-      RequestTemplates: this.getSqsIntegrationRequestTemplates(http)
+      )
+      integration.RequestTemplates = this.getSqsIntegrationRequestTemplates(http)
     }
 
     let integrationResponse
@@ -146,29 +160,6 @@ module.exports = {
   getSqsIntegrationRequestTemplates(http) {
     const defaultRequestTemplates = this.getDefaultSqsRequestTemplates(http)
     const customRequestTemplates = _.get(http, ['request', 'template'])
-    let requestParametersQuerystrings = _.pickBy(
-      http.requestParameters,
-      requestParameterIsQuerystring
-    )
-
-    if (_.isEmpty(customRequestTemplates) && !_.isEmpty(requestParametersQuerystrings)) {
-      requestParametersQuerystrings = _.map(requestParametersQuerystrings, (value, parameter) => {
-        return [
-          parameter.trim().replace('integration.request.querystring.', ''),
-          value
-            .trim()
-            .replace(/^context\.(.+)$/, '$$util.urlEncode($$context.$1)')
-            .replace(/(^')|('$)/g, '')
-        ].join('=')
-      })
-
-      return {
-        'application/json': `${
-          defaultRequestTemplates['application/json']
-        }&${requestParametersQuerystrings.join('&')}`
-      }
-    }
-
     return Object.assign(defaultRequestTemplates, customRequestTemplates)
   },
 

--- a/lib/package/sqs/compileMethodsToSqs.test.js
+++ b/lib/package/sqs/compileMethodsToSqs.test.js
@@ -73,12 +73,12 @@ describe('#compileMethodsToSqs()', () => {
                 }
               ]
             },
-            PassthroughBehavior: 'NEVER',
             RequestParameters: {
-              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
+              'integration.request.querystring.Action': "'SendMessage'",
+              'integration.request.querystring.MessageBody': 'method.request.body'
             },
             RequestTemplates: {
-              'application/json': 'Action=SendMessage&MessageBody=$util.urlEncode($input.body)'
+              'application/json': '{statusCode:200}'
             },
             IntegrationResponses: [
               {
@@ -175,12 +175,12 @@ describe('#compileMethodsToSqs()', () => {
                 }
               ]
             },
-            PassthroughBehavior: 'NEVER',
             RequestParameters: {
-              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
+              'integration.request.querystring.Action': "'SendMessage'",
+              'integration.request.querystring.MessageBody': 'method.request.body'
             },
             RequestTemplates: {
-              'application/json': 'Action=SendMessage&MessageBody=$util.urlEncode($input.body)'
+              'application/json': '{statusCode:200}'
             },
             IntegrationResponses: [
               {
@@ -276,12 +276,12 @@ describe('#compileMethodsToSqs()', () => {
                 }
               ]
             },
-            PassthroughBehavior: 'NEVER',
             RequestParameters: {
-              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
+              'integration.request.querystring.Action': "'SendMessage'",
+              'integration.request.querystring.MessageBody': 'method.request.body'
             },
             RequestTemplates: {
-              'application/json': 'Action=SendMessage&MessageBody=$util.urlEncode($input.body)'
+              'application/json': '{statusCode:200}'
             },
             IntegrationResponses: [
               {
@@ -405,12 +405,12 @@ describe('#compileMethodsToSqs()', () => {
                 }
               ]
             },
-            PassthroughBehavior: 'NEVER',
             RequestParameters: {
-              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
+              'integration.request.querystring.Action': "'SendMessage'",
+              'integration.request.querystring.MessageBody': 'method.request.body'
             },
             RequestTemplates: {
-              'application/json': 'Action=SendMessage&MessageBody=$util.urlEncode($input.body)'
+              'application/json': '{statusCode:200}'
             },
             IntegrationResponses: [
               {
@@ -494,12 +494,12 @@ describe('#compileMethodsToSqs()', () => {
                 }
               ]
             },
-            PassthroughBehavior: 'NEVER',
             RequestParameters: {
-              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'"
+              'integration.request.querystring.Action': "'SendMessage'",
+              'integration.request.querystring.MessageBody': 'method.request.body'
             },
             RequestTemplates: {
-              'application/json': 'Action=SendMessage&MessageBody=$util.urlEncode($input.body)'
+              'application/json': '{statusCode:200}'
             },
             IntegrationResponses: [
               {
@@ -583,14 +583,14 @@ describe('#compileMethodsToSqs()', () => {
                 }
               ]
             },
-            PassthroughBehavior: 'NEVER',
             RequestParameters: {
-              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'",
+              'integration.request.querystring.Action': "'SendMessage'",
+              'integration.request.querystring.MessageBody': 'method.request.body',
               key1: 'value1',
               key2: 'value2'
             },
             RequestTemplates: {
-              'application/json': 'Action=SendMessage&MessageBody=$util.urlEncode($input.body)'
+              'application/json': '{statusCode:200}'
             },
             IntegrationResponses: [
               {
@@ -880,14 +880,22 @@ describe('#compileMethodsToSqs()', () => {
                 }
               ]
             },
-            PassthroughBehavior: 'NEVER',
             RequestParameters: {
-              'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'",
-              'integration.request.header.x-my-custom-header': "'foobar'"
+              'integration.request.header.x-my-custom-header': "'foobar'",
+              'integration.request.querystring.Action': "'SendMessage'",
+              'integration.request.querystring.MessageAttribute.1.Name': "'cognitoIdentityId'",
+              'integration.request.querystring.MessageAttribute.1.Value.DataType': "'String'",
+              'integration.request.querystring.MessageAttribute.1.Value.StringValue':
+                'context.identity.cognitoIdentityId',
+              'integration.request.querystring.MessageAttribute.2.Name':
+                "'cognitoAuthenticationProvider'",
+              'integration.request.querystring.MessageAttribute.2.Value.DataType': "'String'",
+              'integration.request.querystring.MessageAttribute.2.Value.StringValue':
+                'context.identity.cognitoAuthenticationProvider',
+              'integration.request.querystring.MessageBody': 'method.request.body'
             },
             RequestTemplates: {
-              'application/json':
-                'Action=SendMessage&MessageBody=$util.urlEncode($input.body)&MessageAttribute.1.Name=cognitoIdentityId&MessageAttribute.1.Value.StringValue=$util.urlEncode($context.identity.cognitoIdentityId)&MessageAttribute.1.Value.DataType=String&MessageAttribute.2.Name=cognitoAuthenticationProvider&MessageAttribute.2.Value.StringValue=$util.urlEncode($context.identity.cognitoAuthenticationProvider)&MessageAttribute.2.Value.DataType=String'
+              'application/json': '{statusCode:200}'
             },
             IntegrationResponses: [
               {


### PR DESCRIPTION
A different approach to backward compatibility. Basically allows existing implementations to work exactly the same way.

If there is a custom request body specified, we do things differently. Firstly, we don't use any query string values if they are present (they need to be passed into the body if there is a body). We also disable pass-through of headers from the client. These also have to bo explicitly passed through via the body.

Fixes tests which broke during merge of #86.

Allows #94 to be closed without merge.