### PR TITLE
fix: use AWS::Partition pseudo-parameter in ARNs

### DIFF
--- a/lib/package/dynamodb/compileIamRoleToDynamodb.js
+++ b/lib/package/dynamodb/compileIamRoleToDynamodb.js
@@ -26,7 +26,7 @@ module.exports = {
         Action: `dynamodb:${action}`,
         Resource: {
           'Fn::Sub': [
-            'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}',
+            'arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}',
             { tableName }
           ]
         }

--- a/lib/package/dynamodb/compileIamRoleToDynamodb.test.js
+++ b/lib/package/dynamodb/compileIamRoleToDynamodb.test.js
@@ -96,7 +96,7 @@ describe('#compileIamRoleToDynamodb()', () => {
                     Action: 'dynamodb:PutItem',
                     Resource: {
                       'Fn::Sub': [
-                        'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}',
+                        'arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}',
                         {
                           tableName: { Ref: 'mytable' }
                         }
@@ -108,7 +108,7 @@ describe('#compileIamRoleToDynamodb()', () => {
                     Action: 'dynamodb:GetItem',
                     Resource: {
                       'Fn::Sub': [
-                        'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}',
+                        'arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}',
                         {
                           tableName: 'mytable'
                         }
@@ -120,7 +120,7 @@ describe('#compileIamRoleToDynamodb()', () => {
                     Action: 'dynamodb:DeleteItem',
                     Resource: {
                       'Fn::Sub': [
-                        'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}',
+                        'arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}',
                         {
                           tableName: 'mytable'
                         }

--- a/lib/package/dynamodb/compileMethodsToDynamodb.js
+++ b/lib/package/dynamodb/compileMethodsToDynamodb.js
@@ -53,7 +53,7 @@ module.exports = {
       },
       Uri: {
         'Fn::Sub': [
-          'arn:aws:apigateway:${AWS::Region}:dynamodb:action/${action}',
+          'arn:${AWS::Partition}:apigateway:${AWS::Region}:dynamodb:action/${action}',
           { action: http.action }
         ]
       },

--- a/lib/package/dynamodb/compileMethodsToDynamodb.test.js
+++ b/lib/package/dynamodb/compileMethodsToDynamodb.test.js
@@ -146,7 +146,7 @@ describe('#compileMethodsToDynamodb()', () => {
 
     const uri = {
       'Fn::Sub': [
-        'arn:aws:apigateway:${AWS::Region}:dynamodb:action/${action}',
+        'arn:${AWS::Partition}:apigateway:${AWS::Region}:dynamodb:action/${action}',
         {
           action: 'PutItem'
         }
@@ -183,7 +183,7 @@ describe('#compileMethodsToDynamodb()', () => {
 
     const uri = {
       'Fn::Sub': [
-        'arn:aws:apigateway:${AWS::Region}:dynamodb:action/${action}',
+        'arn:${AWS::Partition}:apigateway:${AWS::Region}:dynamodb:action/${action}',
         {
           action: 'GetItem'
         }
@@ -220,7 +220,7 @@ describe('#compileMethodsToDynamodb()', () => {
 
     const uri = {
       'Fn::Sub': [
-        'arn:aws:apigateway:${AWS::Region}:dynamodb:action/${action}',
+        'arn:${AWS::Partition}:apigateway:${AWS::Region}:dynamodb:action/${action}',
         {
           action: 'DeleteItem'
         }
@@ -757,7 +757,7 @@ describe('#compileMethodsToDynamodb()', () => {
               Credentials: { 'Fn::GetAtt': ['ApigatewayToDynamodbRole', 'Arn'] },
               Uri: {
                 'Fn::Sub': [
-                  'arn:aws:apigateway:${AWS::Region}:dynamodb:action/${action}',
+                  'arn:${AWS::Partition}:apigateway:${AWS::Region}:dynamodb:action/${action}',
                   { action: 'PutItem' }
                 ]
               },
@@ -873,7 +873,7 @@ describe('#compileMethodsToDynamodb()', () => {
               Credentials: { 'Fn::GetAtt': ['ApigatewayToDynamodbRole', 'Arn'] },
               Uri: {
                 'Fn::Sub': [
-                  'arn:aws:apigateway:${AWS::Region}:dynamodb:action/${action}',
+                  'arn:${AWS::Partition}:apigateway:${AWS::Region}:dynamodb:action/${action}',
                   { action: 'PutItem' }
                 ]
               },

--- a/lib/package/eventbridge/compileIamRoleToEventBridge.js
+++ b/lib/package/eventbridge/compileIamRoleToEventBridge.js
@@ -19,7 +19,7 @@ module.exports = {
 
     const policyResource = eventBusNames.map((eventBusName) => ({
       'Fn::Sub': [
-        'arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBusName}',
+        'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBusName}',
         { eventBusName }
       ]
     }))

--- a/lib/package/eventbridge/compileIamRoleToEventBridge.test.js
+++ b/lib/package/eventbridge/compileIamRoleToEventBridge.test.js
@@ -83,13 +83,13 @@ describe('#compileIamRoleToEventBridge()', () => {
                     Resource: [
                       {
                         'Fn::Sub': [
-                          'arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBusName}',
+                          'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBusName}',
                           { eventBusName: { Ref: 'EventBus1' } }
                         ]
                       },
                       {
                         'Fn::Sub': [
-                          'arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBusName}',
+                          'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBusName}',
                           { eventBusName: { Ref: 'EventBus2' } }
                         ]
                       }

--- a/lib/package/eventbridge/compileMethodsToEventBridge.js
+++ b/lib/package/eventbridge/compileMethodsToEventBridge.js
@@ -53,7 +53,7 @@ module.exports = {
       Type: 'AWS',
       Credentials: roleArn,
       Uri: {
-        'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:events:action/PutEvents'
+        'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:events:action/PutEvents'
       },
       PassthroughBehavior: 'NEVER',
       RequestParameters: {

--- a/lib/package/eventbridge/compileMethodsToEventBridge.test.js
+++ b/lib/package/eventbridge/compileMethodsToEventBridge.test.js
@@ -69,7 +69,7 @@ describe('#compileMethodsToEventBridge()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToEventBridgeRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:events:action/PutEvents'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:events:action/PutEvents'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {
@@ -189,7 +189,7 @@ describe('#compileMethodsToEventBridge()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToEventBridgeRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:events:action/PutEvents'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:events:action/PutEvents'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {
@@ -308,7 +308,7 @@ describe('#compileMethodsToEventBridge()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToEventBridgeRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:events:action/PutEvents'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:events:action/PutEvents'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {
@@ -687,7 +687,7 @@ describe('#compileMethodsToEventBridge()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToEventBridgeRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:events:action/PutEvents'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:events:action/PutEvents'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {
@@ -794,7 +794,7 @@ describe('#compileMethodsToEventBridge()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToEventBridgeRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:events:action/PutEvents'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:events:action/PutEvents'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {

--- a/lib/package/kinesis/compileIamRoleToKinesis.js
+++ b/lib/package/kinesis/compileIamRoleToKinesis.js
@@ -19,7 +19,7 @@ module.exports = {
 
     const policyResource = kinesisStreamNames.map((streamName) => ({
       'Fn::Sub': [
-        'arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}',
+        'arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}',
         { streamName }
       ]
     }))

--- a/lib/package/kinesis/compileIamRoleToKinesis.test.js
+++ b/lib/package/kinesis/compileIamRoleToKinesis.test.js
@@ -83,13 +83,13 @@ describe('#compileIamRoleToKinesis()', () => {
                     Resource: [
                       {
                         'Fn::Sub': [
-                          'arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}',
+                          'arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}',
                           { streamName: { Ref: 'KinesisStream1' } }
                         ]
                       },
                       {
                         'Fn::Sub': [
-                          'arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}',
+                          'arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}',
                           { streamName: { Ref: 'KinesisStream2' } }
                         ]
                       }

--- a/lib/package/kinesis/compileMethodsToKinesis.js
+++ b/lib/package/kinesis/compileMethodsToKinesis.js
@@ -53,7 +53,7 @@ module.exports = {
       Type: 'AWS',
       Credentials: roleArn,
       Uri: {
-        'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecord'
+        'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:kinesis:action/PutRecord'
       },
       PassthroughBehavior: 'NEVER',
       RequestTemplates: this.getKinesisIntegrationRequestTemplates(http)

--- a/lib/package/kinesis/compileMethodsToKinesis.test.js
+++ b/lib/package/kinesis/compileMethodsToKinesis.test.js
@@ -68,7 +68,7 @@ describe('#compileMethodsToKinesis()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecord'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:kinesis:action/PutRecord'
             },
             PassthroughBehavior: 'NEVER',
             RequestTemplates: {
@@ -181,7 +181,7 @@ describe('#compileMethodsToKinesis()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecord'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:kinesis:action/PutRecord'
             },
             PassthroughBehavior: 'NEVER',
             RequestTemplates: {
@@ -293,7 +293,7 @@ describe('#compileMethodsToKinesis()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecord'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:kinesis:action/PutRecord'
             },
             PassthroughBehavior: 'NEVER',
             RequestTemplates: {
@@ -707,7 +707,7 @@ describe('#compileMethodsToKinesis()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecord'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:kinesis:action/PutRecord'
             },
             PassthroughBehavior: 'NEVER',
             RequestTemplates: {
@@ -807,7 +807,7 @@ describe('#compileMethodsToKinesis()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToKinesisRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecord'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:kinesis:action/PutRecord'
             },
             PassthroughBehavior: 'NEVER',
             RequestTemplates: {

--- a/lib/package/s3/compileIamRoleToS3.js
+++ b/lib/package/s3/compileIamRoleToS3.js
@@ -12,7 +12,14 @@ function convertToArn(bucket) {
       'Fn::GetAtt': [logicalId, 'Arn']
     }
   } else {
-    return `arn:aws:s3:::${bucket}`
+    return {
+      'Fn::Sub': [
+        'arn:${AWS::Partition}:s3:::${bucket}',
+        {
+          bucket
+        }
+      ]
+    }
   }
 }
 
@@ -40,12 +47,7 @@ module.exports = {
         Effect: 'Allow',
         Action: `s3:${action}*`, // e.g. PutObject*, GetObject*, DeleteObject*
         Resource: {
-          'Fn::Sub': [
-            '${bucket}/*',
-            {
-              bucket: convertToArn(bucket)
-            }
-          ]
+          'Fn::Join': ['', [convertToArn(bucket), '/*']]
         }
       }
     })

--- a/lib/package/s3/compileIamRoleToS3.test.js
+++ b/lib/package/s3/compileIamRoleToS3.test.js
@@ -103,11 +103,19 @@ describe('#compileIamRoleToS3()', () => {
                     Effect: 'Allow',
                     Action: 's3:PutObject*',
                     Resource: {
-                      'Fn::Sub': [
-                        '${bucket}/*',
-                        {
-                          bucket: 'arn:aws:s3:::myBucket'
-                        }
+                      'Fn::Join': [
+                        '',
+                        [
+                          {
+                            'Fn::Sub': [
+                              'arn:${AWS::Partition}:s3:::${bucket}',
+                              {
+                                bucket: 'myBucket'
+                              }
+                            ]
+                          },
+                          '/*'
+                        ]
                       ]
                     }
                   },
@@ -115,11 +123,19 @@ describe('#compileIamRoleToS3()', () => {
                     Effect: 'Allow',
                     Action: 's3:GetObject*',
                     Resource: {
-                      'Fn::Sub': [
-                        '${bucket}/*',
-                        {
-                          bucket: 'arn:aws:s3:::myBucket'
-                        }
+                      'Fn::Join': [
+                        '',
+                        [
+                          {
+                            'Fn::Sub': [
+                              'arn:${AWS::Partition}:s3:::${bucket}',
+                              {
+                                bucket: 'myBucket'
+                              }
+                            ]
+                          },
+                          '/*'
+                        ]
                       ]
                     }
                   },
@@ -127,13 +143,14 @@ describe('#compileIamRoleToS3()', () => {
                     Effect: 'Allow',
                     Action: 's3:DeleteObject*',
                     Resource: {
-                      'Fn::Sub': [
-                        '${bucket}/*',
-                        {
-                          bucket: {
+                      'Fn::Join': [
+                        '',
+                        [
+                          {
                             'Fn::GetAtt': ['MyBucket', 'Arn']
-                          }
-                        }
+                          },
+                          '/*'
+                        ]
                       ]
                     }
                   },
@@ -141,11 +158,19 @@ describe('#compileIamRoleToS3()', () => {
                     Effect: 'Allow',
                     Action: 's3:PutObject*',
                     Resource: {
-                      'Fn::Sub': [
-                        '${bucket}/*',
-                        {
-                          bucket: 'arn:aws:s3:::myBucketV2'
-                        }
+                      'Fn::Join': [
+                        '',
+                        [
+                          {
+                            'Fn::Sub': [
+                              'arn:${AWS::Partition}:s3:::${bucket}',
+                              {
+                                bucket: 'myBucketV2'
+                              }
+                            ]
+                          },
+                          '/*'
+                        ]
                       ]
                     }
                   }

--- a/lib/package/s3/compileMethodsToS3.js
+++ b/lib/package/s3/compileMethodsToS3.js
@@ -153,7 +153,7 @@ module.exports = {
       Type: 'AWS',
       Credentials: roleArn,
       Uri: {
-        'Fn::Sub': ['arn:aws:apigateway:${AWS::Region}:s3:path/' + pather, {}]
+        'Fn::Sub': ['arn:${AWS::Partition}:apigateway:${AWS::Region}:s3:path/' + pather, {}]
       },
       PassthroughBehavior: 'WHEN_NO_MATCH',
       RequestParameters: _.merge(requestParams, http.requestParameters)

--- a/lib/package/s3/compileMethodsToS3.test.js
+++ b/lib/package/s3/compileMethodsToS3.test.js
@@ -18,7 +18,7 @@ const template = {
       Type: 'AWS',
       Credentials: { 'Fn::GetAtt': ['ApigatewayToS3Role', 'Arn'] },
       Uri: {
-        'Fn::Sub': ['arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{object}', {}]
+        'Fn::Sub': ['arn:${AWS::Partition}:apigateway:${AWS::Region}:s3:path/{bucket}/{object}', {}]
       },
       PassthroughBehavior: 'WHEN_NO_MATCH',
       RequestParameters: {},
@@ -402,7 +402,10 @@ describe('#compileMethodsToS3()', () => {
             IntegrationHttpMethod: 'PUT',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToS3Role', 'Arn'] },
             Uri: {
-              'Fn::Sub': ['arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{object}', {}]
+              'Fn::Sub': [
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:s3:path/{bucket}/{object}',
+                {}
+              ]
             },
             PassthroughBehavior: 'WHEN_NO_MATCH',
             RequestParameters: {
@@ -522,7 +525,10 @@ describe('#compileMethodsToS3()', () => {
             IntegrationHttpMethod: 'PUT',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToS3Role', 'Arn'] },
             Uri: {
-              'Fn::Sub': ['arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{object}', {}]
+              'Fn::Sub': [
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:s3:path/{bucket}/{object}',
+                {}
+              ]
             },
             PassthroughBehavior: 'WHEN_NO_MATCH',
             RequestParameters: {
@@ -855,7 +861,7 @@ describe('#compileMethodsToS3()', () => {
             Credentials: { 'Fn::GetAtt': ['ApigatewayToS3Role', 'Arn'] },
             Uri: {
               'Fn::Sub': [
-                'arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{folder}/{item}.xml',
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:s3:path/{bucket}/{folder}/{item}.xml',
                 {}
               ]
             },
@@ -976,7 +982,10 @@ describe('#compileMethodsToS3()', () => {
             IntegrationHttpMethod: 'GET',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToS3Role', 'Arn'] },
             Uri: {
-              'Fn::Sub': ['arn:aws:apigateway:${AWS::Region}:s3:path/{bucket}/{myPath}.xml', {}]
+              'Fn::Sub': [
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:s3:path/{bucket}/{myPath}.xml',
+                {}
+              ]
             },
             PassthroughBehavior: 'WHEN_NO_MATCH',
             RequestParameters: {

--- a/lib/package/sns/compileIamRoleToSns.js
+++ b/lib/package/sns/compileIamRoleToSns.js
@@ -18,7 +18,10 @@ module.exports = {
       })
 
     const policyResource = topicNames.map((topicName) => ({
-      'Fn::Sub': ['arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}', { topicName }]
+      'Fn::Sub': [
+        'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+        { topicName }
+      ]
     }))
 
     const template = {

--- a/lib/package/sns/compileIamRoleToSns.test.js
+++ b/lib/package/sns/compileIamRoleToSns.test.js
@@ -92,13 +92,13 @@ describe('#compileIamRoleToSns()', () => {
                     Resource: [
                       {
                         'Fn::Sub': [
-                          'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                          'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
                           { topicName: { 'Fn::GetAtt': ['SNSTopic1', 'TopicName'] } }
                         ]
                       },
                       {
                         'Fn::Sub': [
-                          'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                          'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
                           { topicName: { 'Fn::GetAtt': ['SNSTopic2', 'TopicName'] } }
                         ]
                       }

--- a/lib/package/sns/compileMethodsToSns.js
+++ b/lib/package/sns/compileMethodsToSns.js
@@ -53,7 +53,7 @@ module.exports = {
       Type: 'AWS',
       Credentials: roleArn,
       Uri: {
-        'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:sns:path//'
+        'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:sns:path//'
       },
       PassthroughBehavior: 'NEVER',
       RequestParameters: {
@@ -112,7 +112,10 @@ module.exports = {
     const { topicName } = http
 
     const topicArn = {
-      'Fn::Sub': ['arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}', { topicName }]
+      'Fn::Sub': [
+        'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+        { topicName }
+      ]
     }
 
     return {

--- a/lib/package/sns/compileMethodsToSns.test.js
+++ b/lib/package/sns/compileMethodsToSns.test.js
@@ -68,7 +68,7 @@ describe('#compileMethodsToSns()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:sns:path//'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:sns:path//'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {
@@ -82,7 +82,7 @@ describe('#compileMethodsToSns()', () => {
                     "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
                     {
                       'Fn::Sub': [
-                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
                         { topicName: 'myTopic' }
                       ]
                     },
@@ -97,7 +97,7 @@ describe('#compileMethodsToSns()', () => {
                     "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
                     {
                       'Fn::Sub': [
-                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
                         { topicName: 'myTopic' }
                       ]
                     },
@@ -194,7 +194,7 @@ describe('#compileMethodsToSns()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:sns:path//'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:sns:path//'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {
@@ -208,7 +208,7 @@ describe('#compileMethodsToSns()', () => {
                     "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
                     {
                       'Fn::Sub': [
-                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
                         { topicName: 'myTopic' }
                       ]
                     },
@@ -223,7 +223,7 @@ describe('#compileMethodsToSns()', () => {
                     "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
                     {
                       'Fn::Sub': [
-                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
                         { topicName: 'myTopic' }
                       ]
                     },
@@ -319,7 +319,7 @@ describe('#compileMethodsToSns()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:sns:path//'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:sns:path//'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {
@@ -333,7 +333,7 @@ describe('#compileMethodsToSns()', () => {
                     "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
                     {
                       'Fn::Sub': [
-                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
                         { topicName: 'myTopic' }
                       ]
                     },
@@ -348,7 +348,7 @@ describe('#compileMethodsToSns()', () => {
                     "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
                     {
                       'Fn::Sub': [
-                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
                         { topicName: 'myTopic' }
                       ]
                     },
@@ -427,7 +427,7 @@ describe('#compileMethodsToSns()', () => {
         "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
         {
           'Fn::Sub': [
-            'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+            'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
             { topicName: 'myTopic' }
           ]
         },
@@ -485,7 +485,7 @@ describe('#compileMethodsToSns()', () => {
         "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
         {
           'Fn::Sub': [
-            'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+            'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
             { topicName: 'myTopic' }
           ]
         },
@@ -588,7 +588,7 @@ describe('#compileMethodsToSns()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:sns:path//'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:sns:path//'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {
@@ -602,7 +602,7 @@ describe('#compileMethodsToSns()', () => {
                     "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
                     {
                       'Fn::Sub': [
-                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
                         { topicName: 'myTopic' }
                       ]
                     },
@@ -617,7 +617,7 @@ describe('#compileMethodsToSns()', () => {
                     "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
                     {
                       'Fn::Sub': [
-                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
                         { topicName: 'myTopic' }
                       ]
                     },
@@ -701,7 +701,7 @@ describe('#compileMethodsToSns()', () => {
             Type: 'AWS',
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSnsRole', 'Arn'] },
             Uri: {
-              'Fn::Sub': 'arn:aws:apigateway:${AWS::Region}:sns:path//'
+              'Fn::Sub': 'arn:${AWS::Partition}:apigateway:${AWS::Region}:sns:path//'
             },
             PassthroughBehavior: 'NEVER',
             RequestParameters: {
@@ -715,7 +715,7 @@ describe('#compileMethodsToSns()', () => {
                     "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
                     {
                       'Fn::Sub': [
-                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
                         { topicName: 'myTopic' }
                       ]
                     },
@@ -730,7 +730,7 @@ describe('#compileMethodsToSns()', () => {
                     "Action=Publish&Message=$util.urlEncode($input.body)&TopicArn=$util.urlEncode('",
                     {
                       'Fn::Sub': [
-                        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
+                        'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}',
                         { topicName: 'myTopic' }
                       ]
                     },

--- a/lib/package/sqs/compileIamRoleToSqs.js
+++ b/lib/package/sqs/compileIamRoleToSqs.js
@@ -18,7 +18,10 @@ module.exports = {
       })
 
     const policyResource = sqsQueueNames.map((queueName) => ({
-      'Fn::Sub': ['arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}', { queueName }]
+      'Fn::Sub': [
+        'arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}',
+        { queueName }
+      ]
     }))
 
     const template = {

--- a/lib/package/sqs/compileIamRoleToSqs.test.js
+++ b/lib/package/sqs/compileIamRoleToSqs.test.js
@@ -85,13 +85,13 @@ describe('#compileIamRoleToSqs()', () => {
                     Resource: [
                       {
                         'Fn::Sub': [
-                          'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}',
+                          'arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}',
                           { queueName: { 'Fn::GetAtt': ['SQSQueue1', 'QueueName'] } }
                         ]
                       },
                       {
                         'Fn::Sub': [
-                          'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}',
+                          'arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}',
                           { queueName: { 'Fn::GetAtt': ['SQSQueue2', 'QueueName'] } }
                         ]
                       }

--- a/lib/package/sqs/compileMethodsToSqs.js
+++ b/lib/package/sqs/compileMethodsToSqs.js
@@ -57,7 +57,7 @@ module.exports = {
       Credentials: roleArn,
       Uri: {
         'Fn::Sub': [
-          'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+          'arn:${AWS::Partition}:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
           { queueName: http.queueName }
         ]
       }

--- a/lib/package/sqs/compileMethodsToSqs.test.js
+++ b/lib/package/sqs/compileMethodsToSqs.test.js
@@ -67,7 +67,7 @@ describe('#compileMethodsToSqs()', () => {
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
               'Fn::Sub': [
-                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
                 {
                   queueName: 'myQueue'
                 }
@@ -169,7 +169,7 @@ describe('#compileMethodsToSqs()', () => {
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
               'Fn::Sub': [
-                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
                 {
                   queueName: 'myQueue'
                 }
@@ -270,7 +270,7 @@ describe('#compileMethodsToSqs()', () => {
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
               'Fn::Sub': [
-                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
                 {
                   queueName: 'myQueue'
                 }
@@ -399,7 +399,7 @@ describe('#compileMethodsToSqs()', () => {
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
               'Fn::Sub': [
-                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
                 {
                   queueName: 'myQueue'
                 }
@@ -488,7 +488,7 @@ describe('#compileMethodsToSqs()', () => {
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
               'Fn::Sub': [
-                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
                 {
                   queueName: 'myQueue'
                 }
@@ -577,7 +577,7 @@ describe('#compileMethodsToSqs()', () => {
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
               'Fn::Sub': [
-                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
                 {
                   queueName: 'myQueue'
                 }
@@ -672,7 +672,7 @@ describe('#compileMethodsToSqs()', () => {
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
               'Fn::Sub': [
-                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
                 {
                   queueName: 'myQueue'
                 }
@@ -775,7 +775,7 @@ describe('#compileMethodsToSqs()', () => {
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
               'Fn::Sub': [
-                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
                 {
                   queueName: 'myQueue'
                 }
@@ -874,7 +874,7 @@ describe('#compileMethodsToSqs()', () => {
             Credentials: { 'Fn::GetAtt': ['ApigatewayToSqsRole', 'Arn'] },
             Uri: {
               'Fn::Sub': [
-                'arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/${queueName}',
                 {
                   queueName: 'myQueue'
                 }


### PR DESCRIPTION
Previously the plugin constructed ARNs assuming that they will all be in
`arn:aws:...`, which would cause failures when deploying to an alternate
AWS partition.

This changes the plugin to use the AWS::Partition pseudo-parameter to
ensure that the local partition value is used.

Fixes #85 .