### PR TITLE
feat(dynamodb): custom request mapping templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@ matrix:
   include:
     - node_js: '8.9'
       env:
-        - INTEGRATION_TESTS=false
+        - DISABLE_INTEGRATION_TESTS=true
+    - node_js: '10.6'
     - node_js: '10.6'
       env:
-        - INTEGRATION_TESTS=true
-    - node_js: '10.6'
-      env:
-        - DISABLE_TESTS=true
+        - DISABLE_INTEGRATION_TESTS=true
+        - DISABLE_UNIT_TESTS=true
         - LINTING=true
 
 sudo: false
@@ -19,9 +18,9 @@ install:
   - travis_retry npm install
 
 script:
-  - if [[ -z "$DISABLE_TESTS" ]]; then npm run test; fi
+  - if [[ -z "$DISABLE_UNIT_TESTS" ]]; then npm run test; fi
   - if [[ ! -z "$DISABLE_TESTS" && ! -z "$LINTING" ]]; then npm run lint; fi
-  - if [[ ! -z "$INTEGRATION_TESTS" ]]; then npm run integration-test; fi
+  - if [[ -z "$DISABLE_INTEGRATION_TESTS" ]]; then npm run integration-test; fi
 
 after_success:
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: node_js
 matrix:
   include:
     - node_js: '8.9'
+      env:
+        - INTEGRATION_TESTS=false
     - node_js: '10.6'
       env:
         - INTEGRATION_TESTS=true
@@ -19,7 +21,7 @@ install:
 script:
   - if [[ -z "$DISABLE_TESTS" ]]; then npm run test; fi
   - if [[ ! -z "$DISABLE_TESTS" && ! -z "$LINTING" ]]; then npm run lint; fi
-  - if [[ ! -z "$INTEGRATION_TESTS" && $TRAVIS_BRANCH == "master" && $TRAVIS_PULL_REQUEST == "false" ]]; then npm run integration-test; fi
+  - if [[ ! -z "$INTEGRATION_TESTS" ]]; then npm run integration-test; fi
 
 after_success:
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 
 script:
   - if [[ -z "$DISABLE_UNIT_TESTS" ]]; then npm run test; fi
-  - if [[ ! -z "$DISABLE_TESTS" && ! -z "$LINTING" ]]; then npm run lint; fi
+  - if [[ ! -z "$LINTING" ]]; then npm run lint; fi
   - if [[ -z "$DISABLE_INTEGRATION_TESTS" ]]; then npm run integration-test; fi
 
 after_success:

--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -278,7 +278,8 @@ const proxiesSchemas = {
       tableName: stringOrRef.required(),
       condition: Joi.string(),
       hashKey: dynamodbDefaultKeyScheme.required(),
-      rangeKey: dynamodbDefaultKeyScheme
+      rangeKey: dynamodbDefaultKeyScheme,
+      request
     })
   }),
   eventbridge: Joi.object({

--- a/lib/apiGateway/validate.test.js
+++ b/lib/apiGateway/validate.test.js
@@ -2169,5 +2169,24 @@ describe('#validateServiceProxies()', () => {
 
       expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.not.throw()
     })
+
+    it('should not throw error if request is a mapping template object', () => {
+      serverlessApigatewayServiceProxy.serverless.service.custom = {
+        apiGatewayServiceProxies: [
+          {
+            dynamodb: {
+              tableName: 'yourTable',
+              path: 'dynamodb',
+              method: 'put',
+              action: 'PutItem',
+              hashKey: { pathParam: 'id', attributeType: 'S' },
+              request: { template: { 'application/json': 'mapping template' } }
+            }
+          }
+        ]
+      }
+
+      expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.not.throw()
+    })
   })
 })

--- a/lib/package/dynamodb/compileMethodsToDynamodb.test.js
+++ b/lib/package/dynamodb/compileMethodsToDynamodb.test.js
@@ -393,6 +393,30 @@ describe('#compileMethodsToDynamodb()', () => {
         {}
       )
     })
+
+    it('should create a custom request template when one is given', () => {
+      const customRequestTemplate = "#set($inputRoot = $input.path('$'))\n{ }"
+      testPutItem(
+        {
+          hashKey: { pathParam: 'id', attributeType: 'S' },
+          rangeKey: { pathParam: 'range', attributeType: 'S' },
+          path: '/dynamodb/{id}/{range}',
+          condition: 'attribute_not_exists(id)',
+          action: 'PutItem',
+          request: {
+            template: {
+              'application/json': customRequestTemplate,
+              'application/x-www-form-urlencoded': customRequestTemplate
+            }
+          }
+        },
+        {
+          'application/json': customRequestTemplate,
+          'application/x-www-form-urlencoded': customRequestTemplate
+        },
+        {}
+      )
+    })
   })
 
   describe('#get method', () => {


### PR DESCRIPTION
Adding custom RequestTemplates was disallowed by the schema definition for the dynamo proxy. I've added to that schema and added a new test for the schema change. 

But, there was already an [`Object.assign` call](https://github.com/serverless-operations/serverless-apigateway-service-proxy/blob/v1.11.1/lib/package/dynamodb/compileMethodsToDynamodb.js#L100)  to merge the package-default RequestTemplate with any template defined in the serverless.yaml file. So ... either this was an easy implementation or I've missed some detail as to why the approach in my PR is invalid. So, I just added a test to check the custom request template would be applied.

Let me know if I've missed something which stops support of the custom request templates here.

If not, I'd like to add docs for these before any merging.

It's my hope that this answers the request half of https://github.com/serverless-operations/serverless-apigateway-service-proxy/issues/82