### PR TITLE
Feature: support for s3 request & response templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ This Serverless Framework plugin supports the AWS service proxy integration feat
     - [Customizing responses](#customizing-responses)
   - [S3](#s3)
     - [Customizing request parameters](#customizing-request-parameters-1)
+    - [Customizing request templates](#customizing-request-templates)
     - [Customize the Path Override in API Gateway](#customize-the-path-override-in-api-gateway)
       - [Can use greedy, for deeper Folders](#can-use-greedy--for-deeper-folders)
-  - [SNS](#sns)
     - [Customizing responses](#customizing-responses-1)
+  - [SNS](#sns)
+    - [Customizing responses](#customizing-responses-2)
   - [DynamoDB](#dynamodb)
   - [EventBridge](#eventbridge)
 - [Common API Gateway features](#common-api-gateway-features)
@@ -290,6 +292,29 @@ custom:
           'integration.request.header.cache-control': "'public, max-age=31536000, immutable'"
 ```
 
+#### Customizing request templates
+
+If you'd like use custom [API Gateway request templates](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-override-request-response-parameters.html), you can do so like so:
+
+```yml
+custom:
+  apiGatewayServiceProxies:
+    - s3:
+        path: /s3
+        method: get
+        action: GetObject
+        bucket:
+          Ref: S3Bucket
+        request:
+          template:
+            application/json: |
+              #set ($specialStuff = $context.request.header.x-special)
+              #set ($context.requestOverride.path.object = $specialStuff.replaceAll('_', '-'))
+              {}
+```
+
+Note that if the client does not provide a `Content-Type` header in the request, [ApiGateway defaults to `application/json`](https://docs.aws.amazon.com/apigateway/latest/developerguide/integration-passthrough-behaviors.html).
+
 #### Customize the Path Override in API Gateway
 
 Added the new customization parameter that lets the user set a custom Path Override in API Gateway other than the `{bucket}/{object}`
@@ -347,6 +372,33 @@ custom:
 ```
 
 This will translate for example `/s3/a/b/c` to `a/b/c.xml`
+
+#### Customizing responses
+
+You can get a simple customization of the responses by providing a template for the possible responses. The template is assumed to be `application/json`.
+
+```yml
+custom:
+  apiGatewayServiceProxies:
+    - s3:
+        path: /s3
+        method: post
+        action: PutObject
+        bucket:
+          Ref: S3Bucket
+        key: static-key.json
+        response:
+          template:
+            # `success` is used when the integration response is 200
+            success: |-
+              { "message: "accepted" }
+            # `clientError` is used when the integration response is 400
+            clientError: |-
+              { "message": "there is an error in your request" }
+            # `serverError` is used when the integration response is 500
+            serverError: |-
+              { "message": "there was an error handling your request" }
+```
 
 ### SNS
 

--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -260,9 +260,14 @@ const proxiesSchemas = {
           .keys({ 'integration.request.path.object': Joi.string().required() })
           .required(),
         then: Joi.forbidden(),
-        otherwise: key.required()
+        otherwise: Joi.when('request', {
+          is: request.required(),
+          then: key,
+          otherwise: key.required()
+        })
       }),
-      requestParameters
+      requestParameters,
+      request
     })
   }),
   sns: Joi.object({

--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -267,7 +267,8 @@ const proxiesSchemas = {
         })
       }),
       requestParameters,
-      request
+      request,
+      response: extendedResponse
     })
   }),
   sns: Joi.object({

--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -254,15 +254,18 @@ const proxiesSchemas = {
         .valid('GetObject', 'PutObject', 'DeleteObject')
         .required(),
       bucket: stringOrRef.required(),
-      // don't accept a key when requestParameters has a 'integration.request.path.object' property
-      key: Joi.when('requestParameters', {
-        is: requestParameters
-          .keys({ 'integration.request.path.object': Joi.string().required() })
-          .required(),
-        then: Joi.forbidden(),
-        otherwise: Joi.when('request', {
-          is: request.required(),
-          then: key,
+      // key is
+      //   - optional when using a request mapping template
+      //   - forbidden if requestParameter has a 'integration.request.path.object' property
+      //   - otherwise required
+      key: Joi.when('request', {
+        is: request.required(),
+        then: key,
+        otherwise: Joi.when('requestParameters', {
+          is: requestParameters
+            .keys({ 'integration.request.path.object': Joi.string().required() })
+            .required(),
+          then: Joi.forbidden(),
           otherwise: key.required()
         })
       }),

--- a/lib/apiGateway/validate.test.js
+++ b/lib/apiGateway/validate.test.js
@@ -1283,6 +1283,20 @@ describe('#validateServiceProxies()', () => {
         'integration.request.header.cache-control': "'public, max-age=31536000, immutable'"
       })
     })
+
+    it('should not throw if request template is defined and key is not defined', () => {
+      shouldSucceed('request', { template: {} }, 'key')
+    })
+
+    it('should not throw if request template is defined and key is defined', () => {
+      shouldSucceed('request', { template: {} })
+    })
+
+    it('should not throw if response template is defined', () => {
+      shouldSucceed('response', { template: {} })
+      shouldSucceed('response', { template: { clientError: 'not empty' } })
+      shouldSucceed('response', { template: { success: 'a', clientError: 'b', serverError: 'c' } })
+    })
   })
 
   describe('sns', () => {

--- a/lib/package/s3/compileMethodsToS3.js
+++ b/lib/package/s3/compileMethodsToS3.js
@@ -119,6 +119,11 @@ module.exports = {
     }
   },
 
+  getS3IntegrationResponseTemplate(http, statusType) {
+    const template = _.get(http, ['response', 'template', statusType])
+    return Object.assign({}, template && { 'application/json': template })
+  },
+
   getS3MethodIntegration(http) {
     const bucket = http.bucket
     const httpMethod = this.getIntegrationHttpMethod(http)
@@ -172,19 +177,19 @@ module.exports = {
           StatusCode: 400,
           SelectionPattern: '4\\d{2}',
           ResponseParameters: {},
-          ResponseTemplates: {}
+          ResponseTemplates: this.getS3IntegrationResponseTemplate(http, 'clientError')
         },
         {
           StatusCode: 500,
           SelectionPattern: '5\\d{2}',
           ResponseParameters: {},
-          ResponseTemplates: {}
+          ResponseTemplates: this.getS3IntegrationResponseTemplate(http, 'serverError')
         },
         {
           StatusCode: 200,
           SelectionPattern: '2\\d{2}',
           ResponseParameters: responseParams,
-          ResponseTemplates: {}
+          ResponseTemplates: this.getS3IntegrationResponseTemplate(http, 'success')
         }
       ]
     }

--- a/lib/package/s3/compileMethodsToS3.js
+++ b/lib/package/s3/compileMethodsToS3.js
@@ -159,6 +159,13 @@ module.exports = {
       RequestParameters: _.merge(requestParams, http.requestParameters)
     }
 
+    const customRequestTemplates = _.get(http, ['request', 'template'])
+
+    if (!_.isEmpty(customRequestTemplates)) {
+      integration.PassthroughBehavior = 'NEVER'
+      integration.RequestTemplates = customRequestTemplates
+    }
+
     const integrationResponse = {
       IntegrationResponses: [
         {

--- a/lib/package/s3/compileMethodsToS3.test.js
+++ b/lib/package/s3/compileMethodsToS3.test.js
@@ -1050,4 +1050,260 @@ describe('#compileMethodsToS3()', () => {
       }
     })
   })
+
+  it('should create corresponding resources when s3 GetObject proxy is given with request template', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 's3',
+          http: {
+            path: '/{item}',
+            method: 'get',
+            pathOverride: '{folder}/{item}',
+            bucket: {
+              Ref: 'MyBucket'
+            },
+            action: 'GetObject',
+            auth: { authorizationType: 'NONE' },
+            requestParameters: {
+              'integration.request.path.item': 'method.request.path.item'
+            },
+            request: {
+              template: {
+                'foo/bar': 'foo the bars!',
+                'bar/foo': 'bar the foos!'
+              }
+            }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      '/{item}': {
+        name: 'Item',
+        resourceLogicalId: 'ApiGatewayPathOverrideS3'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToS3()
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodItemGet: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          AuthorizationType: 'NONE',
+          AuthorizationScopes: undefined,
+          AuthorizerId: undefined,
+          ApiKeyRequired: false,
+          ResourceId: { Ref: 'ApiGatewayPathOverrideS3' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          RequestParameters: {
+            'method.request.path.item': true
+          },
+          Integration: {
+            Type: 'AWS',
+            IntegrationHttpMethod: 'GET',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToS3Role', 'Arn'] },
+            Uri: {
+              'Fn::Sub': [
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:s3:path/{bucket}/{folder}/{item}',
+                {}
+              ]
+            },
+            PassthroughBehavior: 'NEVER',
+            RequestParameters: {
+              'integration.request.path.bucket': {
+                'Fn::Sub': [
+                  "'${bucket}'",
+                  {
+                    bucket: {
+                      Ref: 'MyBucket'
+                    }
+                  }
+                ]
+              },
+              'integration.request.path.item': 'method.request.path.item'
+            },
+            RequestTemplates: {
+              'bar/foo': 'bar the foos!',
+              'foo/bar': 'foo the bars!'
+            },
+            IntegrationResponses: [
+              {
+                StatusCode: 400,
+                SelectionPattern: '4\\d{2}',
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 500,
+                SelectionPattern: '5\\d{2}',
+                ResponseParameters: {},
+                ResponseTemplates: {}
+              },
+              {
+                StatusCode: 200,
+                SelectionPattern: '2\\d{2}',
+                ResponseParameters: {
+                  'method.response.header.Content-Type': 'integration.response.header.Content-Type',
+                  'method.response.header.content-type': 'integration.response.header.content-type'
+                },
+                ResponseTemplates: {}
+              }
+            ]
+          },
+          MethodResponses: [
+            {
+              ResponseParameters: {
+                'method.response.header.Content-Type': true,
+                'method.response.header.content-type': true
+              },
+              ResponseModels: {},
+              StatusCode: 200
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 400
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 500
+            }
+          ]
+        }
+      }
+    })
+  })
+
+  it('should create corresponding resources when s3 GetObject proxy is given with response templates', () => {
+    serverlessApigatewayServiceProxy.validated = {
+      events: [
+        {
+          serviceName: 's3',
+          http: {
+            path: '/{myKey}',
+            method: 'get',
+            action: 'GetObject',
+            auth: { authorizationType: 'NONE' },
+            bucket: {
+              Ref: 'MyBucket'
+            },
+            key: {
+              pathParam: 'myKey'
+            },
+            response: {
+              template: {
+                success: '{"message": "all good"}',
+                clientError: '{"message": "Your fault"}',
+                serverError: '{"message": "My fault"}'
+              }
+            }
+          }
+        }
+      ]
+    }
+    serverlessApigatewayServiceProxy.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi'
+    serverlessApigatewayServiceProxy.apiGatewayResources = {
+      '/{myKey}': {
+        name: 'MyKey',
+        resourceLogicalId: 'ApiGatewayPathOverrideS3'
+      }
+    }
+
+    serverlessApigatewayServiceProxy.compileMethodsToS3()
+    expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).to.deep.equal({
+      ApiGatewayMethodMyKeyGet: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          AuthorizationType: 'NONE',
+          AuthorizationScopes: undefined,
+          AuthorizerId: undefined,
+          ApiKeyRequired: false,
+          ResourceId: { Ref: 'ApiGatewayPathOverrideS3' },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          RequestParameters: {
+            'method.request.path.myKey': true
+          },
+          Integration: {
+            Type: 'AWS',
+            IntegrationHttpMethod: 'GET',
+            Credentials: { 'Fn::GetAtt': ['ApigatewayToS3Role', 'Arn'] },
+            Uri: {
+              'Fn::Sub': [
+                'arn:${AWS::Partition}:apigateway:${AWS::Region}:s3:path/{bucket}/{object}',
+                {}
+              ]
+            },
+            PassthroughBehavior: 'WHEN_NO_MATCH',
+            RequestParameters: {
+              'integration.request.path.bucket': {
+                'Fn::Sub': [
+                  "'${bucket}'",
+                  {
+                    bucket: {
+                      Ref: 'MyBucket'
+                    }
+                  }
+                ]
+              },
+              'integration.request.path.object': 'method.request.path.myKey'
+            },
+            IntegrationResponses: [
+              {
+                StatusCode: 400,
+                SelectionPattern: '4\\d{2}',
+                ResponseParameters: {},
+                ResponseTemplates: {
+                  'application/json': '{"message": "Your fault"}'
+                }
+              },
+              {
+                StatusCode: 500,
+                SelectionPattern: '5\\d{2}',
+                ResponseParameters: {},
+                ResponseTemplates: {
+                  'application/json': '{"message": "My fault"}'
+                }
+              },
+              {
+                StatusCode: 200,
+                SelectionPattern: '2\\d{2}',
+                ResponseParameters: {
+                  'method.response.header.Content-Type': 'integration.response.header.Content-Type',
+                  'method.response.header.content-type': 'integration.response.header.content-type'
+                },
+                ResponseTemplates: {
+                  'application/json': '{"message": "all good"}'
+                }
+              }
+            ]
+          },
+          MethodResponses: [
+            {
+              ResponseParameters: {
+                'method.response.header.Content-Type': true,
+                'method.response.header.content-type': true
+              },
+              ResponseModels: {},
+              StatusCode: 200
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 400
+            },
+            {
+              ResponseParameters: {},
+              ResponseModels: {},
+              StatusCode: 500
+            }
+          ]
+        }
+      }
+    })
+  })
 })


### PR DESCRIPTION
This PR adds basic support for custom VTL mapping templates for requests & responses when proxying s3.

The request templates follow the same pattern already in use by Kinesis, SQS and SNS.

The response templates follow the same pattern already in use by SQS and SNS.

Docs & tests are included. Let me know if you'd like to see any changes or whatnot. Thank you!

Fixes #106, #81 