### PR TITLE
fix: add request property to EventBridge schema

### DIFF
--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -308,7 +308,8 @@ const proxiesSchemas = {
       eventBusName: stringOrRef.required(),
       source: eventBridgeSource.required(),
       detailType: eventBridgeDetailType,
-      detail: eventBridgeDetail
+      detail: eventBridgeDetail,
+      request
     })
   })
 }

--- a/lib/apiGateway/validate.test.js
+++ b/lib/apiGateway/validate.test.js
@@ -2271,5 +2271,26 @@ describe('#validateServiceProxies()', () => {
 
       expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.not.throw()
     })
+
+    it('should throw error if eventbridge request is missing the template property', () => {
+      serverlessApigatewayServiceProxy.serverless.service.custom = {
+        apiGatewayServiceProxies: [
+          {
+            eventbridge: {
+              eventBusName: 'yourBus',
+              source: 'proxy.apigw',
+              path: 'eventbridge',
+              method: 'post',
+              request: { xxx: { 'application/json': 'mappingTemplate' } }
+            }
+          }
+        ]
+      }
+
+      expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.throw(
+        serverless.classes.Error,
+        'child "eventbridge" fails because [child "request" fails because [child "template" fails because ["template" is required]]]'
+      )
+    })
   })
 })

--- a/lib/apiGateway/validate.test.js
+++ b/lib/apiGateway/validate.test.js
@@ -2271,7 +2271,9 @@ describe('#validateServiceProxies()', () => {
 
       expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.not.throw()
     })
+  })
 
+  describe('eventbridge', () => {
     it('should throw error if eventbridge request is missing the template property', () => {
       serverlessApigatewayServiceProxy.serverless.service.custom = {
         apiGatewayServiceProxies: [


### PR DESCRIPTION
This adds the `request` property to the EventBridge schema object. I have also added a test that fails if the `request` property is removed from the EventBridge schema.

The test would fail with:

```
 281 passing (584ms)
  1 failing

  1) #validateServiceProxies()
       eventbridge
         should throw error if eventbridge request is missing the template property:

      AssertionError: expected [Function] to throw error including 'child "eventbridge" fails because [ch…' but got 'child "eventbridge" fails because ["r…'
      + expected - actual

      -child "eventbridge" fails because ["request" is not allowed]
      +child "eventbridge" fails because [child "request" fails because [child "template" fails because ["template" is required]]]
      
      at Context.<anonymous> (lib/apiGateway/validate.test.js:2290:87)
      at processImmediate (internal/timers.js:464:21)
```

Fixes #156
