### PR TITLE
feat: dynamodb plain keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,8 +524,9 @@ custom:
         hashKey:
           queryStringParam: id # use query string parameter
           attributeType: S
-        rangeKey:
-          queryStringParam: sort
+        rangeKey: # use static value for sort key
+          name: sort
+          value: 'static-sort-key-value'
           attributeType: S
         action: GetItem
         cors: true

--- a/lib/apiGateway/schema.js
+++ b/lib/apiGateway/schema.js
@@ -153,13 +153,18 @@ const dynamodbDefaultKeyScheme = Joi.object()
   .keys({
     pathParam: Joi.string(),
     queryStringParam: Joi.string(),
-    attributeType: Joi.string().required()
+    attributeType: Joi.string().required(),
+    name: Joi.string(),
+    value: Joi.any().when('name', {
+      is: Joi.exist(),
+      then: Joi.required()
+    })
   })
-  .xor('pathParam', 'queryStringParam')
+  .xor('pathParam', 'queryStringParam', 'name')
   .error(
     customErrorBuilder(
       'object.xor',
-      'key must contain "pathParam" or "queryStringParam" and only one'
+      'key must contain "pathParam", "queryStringParam" or "name" and only one'
     )
   )
 

--- a/lib/apiGateway/validate.test.js
+++ b/lib/apiGateway/validate.test.js
@@ -1847,7 +1847,7 @@ describe('#validateServiceProxies()', () => {
       }
 
       expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.throw(
-        'child "dynamodb" fails because [child "hashKey" fails because ["hashKey" must contain at least one of [pathParam, queryStringParam]]]'
+        'child "dynamodb" fails because [child "hashKey" fails because ["hashKey" must contain at least one of [pathParam, queryStringParam, name]]]'
       )
     })
 
@@ -1992,7 +1992,7 @@ describe('#validateServiceProxies()', () => {
       }
 
       expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.throw(
-        'child "dynamodb" fails because [child "hashKey" fails because [key must contain "pathParam" or "queryStringParam" and only one]]'
+        'child "dynamodb" fails because [child "hashKey" fails because [key must contain "pathParam", "queryStringParam" or "name" and only one]]'
       )
     })
 
@@ -2018,7 +2018,7 @@ describe('#validateServiceProxies()', () => {
       }
 
       expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.throw(
-        'child "dynamodb" fails because [child "rangeKey" fails because ["rangeKey" must contain at least one of [pathParam, queryStringParam]]]'
+        'child "dynamodb" fails because [child "rangeKey" fails because ["rangeKey" must contain at least one of [pathParam, queryStringParam, name]]]'
       )
     })
 
@@ -2164,7 +2164,7 @@ describe('#validateServiceProxies()', () => {
       }
 
       expect(() => serverlessApigatewayServiceProxy.validateServiceProxies()).to.throw(
-        'child "dynamodb" fails because [child "rangeKey" fails because [key must contain "pathParam" or "queryStringParam" and only one]]'
+        'child "dynamodb" fails because [child "rangeKey" fails because [key must contain "pathParam", "queryStringParam" or "name" and only one]]'
       )
     })
 

--- a/lib/package/dynamodb/compileMethodsToDynamodb.js
+++ b/lib/package/dynamodb/compileMethodsToDynamodb.js
@@ -123,6 +123,14 @@ module.exports = {
         attributeValue: `$input.params().querystring.${http.hashKey.queryStringParam}`
       }
     }
+
+    if (http.hashKey.name && http.hashKey.value) {
+      return {
+        key: http.hashKey.name,
+        attributeType: http.hashKey.attributeType,
+        attributeValue: http.hashKey.value
+      }
+    }
   },
 
   getDynamodbObjectRangekeyParameter(http) {
@@ -139,6 +147,14 @@ module.exports = {
         key: http.rangeKey.queryStringParam,
         attributeType: http.rangeKey.attributeType,
         attributeValue: `$input.params().querystring.${http.rangeKey.queryStringParam}`
+      }
+    }
+
+    if (http.rangeKey.name && http.rangeKey.value) {
+      return {
+        key: http.rangeKey.name,
+        attributeType: http.rangeKey.attributeType,
+        attributeValue: http.rangeKey.value
       }
     }
   },

--- a/lib/package/dynamodb/compileMethodsToDynamodb.js
+++ b/lib/package/dynamodb/compileMethodsToDynamodb.js
@@ -108,53 +108,35 @@ module.exports = {
   },
 
   getDynamodbObjectHashkeyParameter(http) {
-    if (http.hashKey.pathParam) {
-      return {
-        key: http.hashKey.pathParam,
-        attributeType: http.hashKey.attributeType,
-        attributeValue: `$input.params().path.${http.hashKey.pathParam}`
-      }
-    }
-
-    if (http.hashKey.queryStringParam) {
-      return {
-        key: http.hashKey.queryStringParam,
-        attributeType: http.hashKey.attributeType,
-        attributeValue: `$input.params().querystring.${http.hashKey.queryStringParam}`
-      }
-    }
-
-    if (http.hashKey.name && http.hashKey.value) {
-      return {
-        key: http.hashKey.name,
-        attributeType: http.hashKey.attributeType,
-        attributeValue: http.hashKey.value
-      }
-    }
+    return this.makeKeyDefinition(http.hashKey)
   },
 
   getDynamodbObjectRangekeyParameter(http) {
-    if (http.rangeKey.pathParam) {
+    return this.makeKeyDefinition(http.rangeKey)
+  },
+
+  makeKeyDefinition(keyParameter) {
+    if (keyParameter.pathParam) {
       return {
-        key: http.rangeKey.pathParam,
-        attributeType: http.rangeKey.attributeType,
-        attributeValue: `$input.params().path.${http.rangeKey.pathParam}`
+        key: keyParameter.pathParam,
+        attributeType: keyParameter.attributeType,
+        attributeValue: `$input.params().path.${keyParameter.pathParam}`
       }
     }
 
-    if (http.rangeKey.queryStringParam) {
+    if (keyParameter.queryStringParam) {
       return {
-        key: http.rangeKey.queryStringParam,
-        attributeType: http.rangeKey.attributeType,
-        attributeValue: `$input.params().querystring.${http.rangeKey.queryStringParam}`
+        key: keyParameter.queryStringParam,
+        attributeType: keyParameter.attributeType,
+        attributeValue: `$input.params().querystring.${keyParameter.queryStringParam}`
       }
     }
 
-    if (http.rangeKey.name && http.rangeKey.value) {
+    if (keyParameter.name && keyParameter.value) {
       return {
-        key: http.rangeKey.name,
-        attributeType: http.rangeKey.attributeType,
-        attributeValue: http.rangeKey.value
+        key: keyParameter.name,
+        attributeType: keyParameter.attributeType,
+        attributeValue: keyParameter.value
       }
     }
   },

--- a/lib/package/dynamodb/compileMethodsToDynamodb.test.js
+++ b/lib/package/dynamodb/compileMethodsToDynamodb.test.js
@@ -296,6 +296,34 @@ describe('#compileMethodsToDynamodb()', () => {
       )
     })
 
+    it('should create corresponding resources when hashKey is given with a plain value', () => {
+      const intRequestTemplate = {
+        'Fn::Sub': [
+          '{"TableName": "${TableName}","Item": {"${HashKey}": {"${HashAttributeType}": "${HashAttributeValue}"},\n      #set ($body = $util.parseJson($input.body))\n      #foreach( $key in $body.keySet())\n        #set ($item = $body.get($key))\n        #foreach( $type in $item.keySet())\n          "$key":{"$type" : "$item.get($type)"}\n        #if($foreach.hasNext()),#end\n        #end\n      #if($foreach.hasNext()),#end\n      #end\n    }\n    }',
+          {
+            TableName: {
+              Ref: 'MyTable'
+            },
+            HashKey: 'id',
+            HashAttributeType: 'S',
+            HashAttributeValue: 'plain-value'
+          }
+        ]
+      }
+      testPutItem(
+        {
+          hashKey: { name: 'id', value: 'plain-value', attributeType: 'S' },
+          path: '/dynamodb',
+          action: 'PutItem'
+        },
+        {
+          'application/json': intRequestTemplate,
+          'application/x-www-form-urlencoded': intRequestTemplate
+        },
+        {}
+      )
+    })
+
     it('should create corresponding resources when rangekey is given with a path parameter', () => {
       const intRequestTemplate = {
         'Fn::Sub': [
@@ -349,6 +377,38 @@ describe('#compileMethodsToDynamodb()', () => {
         {
           hashKey: { pathParam: 'id', attributeType: 'S' },
           rangeKey: { queryStringParam: 'range', attributeType: 'S' },
+          path: '/dynamodb/{id}',
+          action: 'PutItem'
+        },
+        {
+          'application/json': intRequestTemplate,
+          'application/x-www-form-urlencoded': intRequestTemplate
+        },
+        {}
+      )
+    })
+
+    it('should create corresponding resources when rangekey is given with a plain value', () => {
+      const intRequestTemplate = {
+        'Fn::Sub': [
+          '{"TableName": "${TableName}","Item": {"${HashKey}": {"${HashAttributeType}": "${HashAttributeValue}"},"${RangeKey}": {"${RangeAttributeType}": "${RangeAttributeValue}"},\n      #set ($body = $util.parseJson($input.body))\n      #foreach( $key in $body.keySet())\n        #set ($item = $body.get($key))\n        #foreach( $type in $item.keySet())\n          "$key":{"$type" : "$item.get($type)"}\n        #if($foreach.hasNext()),#end\n        #end\n      #if($foreach.hasNext()),#end\n      #end\n    }\n    }',
+          {
+            TableName: {
+              Ref: 'MyTable'
+            },
+            HashKey: 'id',
+            HashAttributeType: 'S',
+            HashAttributeValue: '$input.params().path.id',
+            RangeKey: 'range',
+            RangeAttributeType: 'S',
+            RangeAttributeValue: 'plain-value'
+          }
+        ]
+      }
+      testPutItem(
+        {
+          hashKey: { pathParam: 'id', attributeType: 'S' },
+          rangeKey: { name: 'range', value: 'plain-value', attributeType: 'S' },
           path: '/dynamodb/{id}',
           action: 'PutItem'
         },


### PR DESCRIPTION
With this pull request, you can provide a plain key-value-pair as dynamodb hash- or sortKey. This allows for either providing static values, or provide arbitrary resolutions through vtl that are not covered by the given shortcuts.

I used the following schema, for brevity's sake:
```yaml
name: 'key-name'
value: 'static value'
```
However I'm also up for calling them `attributeName` and `attributeValue` respectively, to keep more in line with the CloudFormation schema declaration.

TODO:
- [ ] Update documentation
- [ ] Probably include the new format in an integration test?