### PR TITLE
fix: method.response.header values should be boolean

### DIFF
--- a/lib/apiGateway/methods.js
+++ b/lib/apiGateway/methods.js
@@ -25,14 +25,9 @@ module.exports = {
     }
 
     if (http && http.cors) {
-      let origin = http.cors.origin
-      if (http.cors.origins && http.cors.origins.length) {
-        origin = http.cors.origins.join(',')
-      }
-
       methodResponse.Properties.MethodResponses.forEach((val, i) => {
         methodResponse.Properties.MethodResponses[i].ResponseParameters = {
-          'method.response.header.Access-Control-Allow-Origin': `'${origin}'`
+          'method.response.header.Access-Control-Allow-Origin': true
         }
       })
     }

--- a/lib/apiGateway/methods.test.js
+++ b/lib/apiGateway/methods.test.js
@@ -42,7 +42,7 @@ describe('#getAllServiceProxies()', () => {
         json1.Properties.MethodResponses[0].ResponseParameters[
           'method.response.header.Access-Control-Allow-Origin'
         ]
-      ).to.equal("'*'")
+      ).to.be.true
 
       const json2 = serverlessApigatewayServiceProxy.getMethodResponses({
         cors: {
@@ -54,7 +54,15 @@ describe('#getAllServiceProxies()', () => {
         json2.Properties.MethodResponses[0].ResponseParameters[
           'method.response.header.Access-Control-Allow-Origin'
         ]
-      ).to.equal("'*,http://example.com'")
+      ).to.be.true
+
+      const json3 = serverlessApigatewayServiceProxy.getMethodResponses({})
+
+      expect(
+        json3.Properties.MethodResponses[0].ResponseParameters[
+          'method.response.header.Access-Control-Allow-Origin'
+        ]
+      ).to.be.undefined
     })
   })
 })

--- a/lib/package/dynamodb/compileMethodsToDynamodb.test.js
+++ b/lib/package/dynamodb/compileMethodsToDynamodb.test.js
@@ -829,17 +829,17 @@ describe('#compileMethodsToDynamodb()', () => {
             },
             MethodResponses: [
               {
-                ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+                ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
                 ResponseModels: {},
                 StatusCode: 200
               },
               {
-                ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+                ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
                 ResponseModels: {},
                 StatusCode: 400
               },
               {
-                ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+                ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
                 ResponseModels: {},
                 StatusCode: 500
               }

--- a/lib/package/eventbridge/compileMethodsToEventBridge.test.js
+++ b/lib/package/eventbridge/compileMethodsToEventBridge.test.js
@@ -243,17 +243,17 @@ describe('#compileMethodsToEventBridge()', () => {
           },
           MethodResponses: [
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 200
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 400
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 500
             }

--- a/lib/package/kinesis/compileMethodsToKinesis.test.js
+++ b/lib/package/kinesis/compileMethodsToKinesis.test.js
@@ -229,17 +229,17 @@ describe('#compileMethodsToKinesis()', () => {
           },
           MethodResponses: [
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 200
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 400
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 500
             }

--- a/lib/package/sns/compileMethodsToSns.test.js
+++ b/lib/package/sns/compileMethodsToSns.test.js
@@ -255,17 +255,17 @@ describe('#compileMethodsToSns()', () => {
           },
           MethodResponses: [
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 200
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 400
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 500
             }

--- a/lib/package/sqs/compileMethodsToSqs.test.js
+++ b/lib/package/sqs/compileMethodsToSqs.test.js
@@ -205,17 +205,17 @@ describe('#compileMethodsToSqs()', () => {
           },
           MethodResponses: [
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 200
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 400
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 500
             }


### PR DESCRIPTION
This fixes API GW method response header value type to be boolean, as it's stated in the CF documentation:

(https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-methodresponse.html)

In this case, value for `method.response.header.Access-Control-Allow-Origin` is now changed from CORS origin string to a boolean. 