### PR TITLE
Fixes selectionPattern documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ custom:
         cors: true
         response:
           - statusCode: 200
-            selectionPattern: '2\\d{2}'
+            selectionPattern: '2\d{2}'
             responseParameters: {}
             responseTemplates:
               application/json: |-
@@ -637,7 +637,7 @@ custom:
         cors: true
         response:
           - statusCode: 200
-            selectionPattern: '2\\d{2}'
+            selectionPattern: '2\d{2}'
             responseParameters: {}
             responseTemplates:
               application/json: |-


### PR DESCRIPTION
I can confirm that the the extra `\` was actually not valid and was causing my response to default to the last template in the list.