### PR TITLE
[README.md] Fix broken json-response in documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ custom:
           template:
             # `success` is used when the integration response is 200
             success: |-
-              { "message: "accepted" }
+              { "message": "accepted" }
             # `clientError` is used when the integration response is 400
             clientError: |-
               { "message": "there is an error in your request" }
@@ -396,7 +396,7 @@ custom:
           template:
             # `success` is used when the integration response is 200
             success: |-
-              { "message: "accepted" }
+              { "message": "accepted" }
             # `clientError` is used when the integration response is 400
             clientError: |-
               { "message": "there is an error in your request" }


### PR DESCRIPTION
Dear Dev-Team. Thanks for this great plugin. I just found a small thing in the README

Response Template taken from the Readme has a `typo`

The response is no valid json:

![image](https://github.com/serverless-operations/serverless-apigateway-service-proxy/assets/19696233/a532e292-af3c-4e58-aecc-2ec73f9bf96c)

