### PR TITLE
fix: fixes incorrect type on MethodResponse ResponseParameters

### DIFF
--- a/lib/apiGateway/methods.js
+++ b/lib/apiGateway/methods.js
@@ -33,14 +33,9 @@ module.exports = {
     }
 
     if (http && http.cors) {
-      let origin = http.cors.origin
-      if (http.cors.origins && http.cors.origins.length) {
-        origin = http.cors.origins.join(',')
-      }
-
       methodResponse.Properties.MethodResponses.forEach((val, i) => {
         methodResponse.Properties.MethodResponses[i].ResponseParameters = {
-          'method.response.header.Access-Control-Allow-Origin': `'${origin}'`
+          'method.response.header.Access-Control-Allow-Origin': true
         }
       })
     }

--- a/lib/apiGateway/methods.test.js
+++ b/lib/apiGateway/methods.test.js
@@ -42,7 +42,7 @@ describe('#getAllServiceProxies()', () => {
         json1.Properties.MethodResponses[0].ResponseParameters[
           'method.response.header.Access-Control-Allow-Origin'
         ]
-      ).to.equal("'*'")
+      ).to.equal(true)
 
       const json2 = serverlessApigatewayServiceProxy.getMethodResponses({
         cors: {
@@ -54,7 +54,7 @@ describe('#getAllServiceProxies()', () => {
         json2.Properties.MethodResponses[0].ResponseParameters[
           'method.response.header.Access-Control-Allow-Origin'
         ]
-      ).to.equal("'*,http://example.com'")
+      ).to.equal(true)
     })
   })
 })

--- a/lib/package/dynamodb/compileMethodsToDynamodb.test.js
+++ b/lib/package/dynamodb/compileMethodsToDynamodb.test.js
@@ -839,17 +839,17 @@ describe('#compileMethodsToDynamodb()', () => {
             },
             MethodResponses: [
               {
-                ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+                ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
                 ResponseModels: {},
                 StatusCode: 200
               },
               {
-                ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+                ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
                 ResponseModels: {},
                 StatusCode: 400
               },
               {
-                ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+                ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
                 ResponseModels: {},
                 StatusCode: 500
               }

--- a/lib/package/eventbridge/compileMethodsToEventBridge.test.js
+++ b/lib/package/eventbridge/compileMethodsToEventBridge.test.js
@@ -243,17 +243,17 @@ describe('#compileMethodsToEventBridge()', () => {
           },
           MethodResponses: [
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 200
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 400
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 500
             }

--- a/lib/package/kinesis/compileMethodsToKinesis.test.js
+++ b/lib/package/kinesis/compileMethodsToKinesis.test.js
@@ -229,17 +229,17 @@ describe('#compileMethodsToKinesis()', () => {
           },
           MethodResponses: [
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 200
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 400
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 500
             }

--- a/lib/package/sns/compileMethodsToSns.test.js
+++ b/lib/package/sns/compileMethodsToSns.test.js
@@ -255,17 +255,17 @@ describe('#compileMethodsToSns()', () => {
           },
           MethodResponses: [
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 200
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 400
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 500
             }

--- a/lib/package/sqs/compileMethodsToSqs.test.js
+++ b/lib/package/sqs/compileMethodsToSqs.test.js
@@ -205,17 +205,17 @@ describe('#compileMethodsToSqs()', () => {
           },
           MethodResponses: [
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 200
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 400
             },
             {
-              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': "'*'" },
+              ResponseParameters: { 'method.response.header.Access-Control-Allow-Origin': true },
               ResponseModels: {},
               StatusCode: 500
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-apigateway-service-proxy",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-apigateway-service-proxy",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@hapi/joi": "^15.1.0",


### PR DESCRIPTION
The type for the ResponseParameters on the MethodResponse is expected to be `Record<string, boolean>` because they're actually a list of required responses, not a list of returned values.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-methodresponse.html#aws-properties-apitgateway-method-methodresponse-properties

https://github.com/serverless-operations/serverless-apigateway-service-proxy/issues/206