### PR TITLE
Update Node to v20 from v14 (AWS Support Depreciated) 

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,13 +9,13 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'ok to test')
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2.1.4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 20
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -30,7 +30,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: coverage

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 20
 
       - name: Cache dependencies
         uses: actions/cache@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-apigateway-service-proxy",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-apigateway-service-proxy",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@hapi/joi": "^15.1.0",
@@ -40,7 +40,7 @@
         "sinon-chai": "^3.3.0"
       },
       "peerDependencies": {
-        "serverless": "3"
+        "serverless": ">=3"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
Update GitHub Action steps to latest versions and update from Node v14 to v20.

[AWS currently supports ](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported)the following Node.js versions:

Node.js v22.x (until April 30, 2027)
Node.js v20.x (until April 30, 2026)
Node.js v18.x (until September 1, 2025)